### PR TITLE
Add support for compressed certificates

### DIFF
--- a/tool/cmdline.ggo
+++ b/tool/cmdline.ggo
@@ -47,7 +47,7 @@ option "pin-retries" - "Number of retries before the pin code is blocked" int op
 option "puk-retries" - "Number of retries before the puk code is blocked" int optional dependon="pin-retries"
 option "input" i "Filename to use as input, - for stdin" string optional default="-"
 option "output" o "Filename to use as output, - for stdout" string optional default="-"
-option "key-format" K "Format of the key being read/written" values="PEM","PKCS12" enum optional default="PEM"
+option "key-format" K "Format of the key being read/written" values="PEM","PKCS12","GZIP" enum optional default="PEM"
 option "password" p "Password for decryption of private key file" string optional
 option "subject" S "The subject to use for certificate request" string optional
 text   "

--- a/tool/yubico-piv-tool.h2m
+++ b/tool/yubico-piv-tool.h2m
@@ -60,6 +60,12 @@ file with password test, into slot 9c:
    yubico-piv-tool -s 9c -i test.pfx -K PKCS12 -p test -a set-chuid \\
      -a import-key -a import-cert
 
+Import a certificate which is larger than 2048 bytes and thus requires
+compression in order to fit:
+
+  openssl x509 -in cert.pem -outform DER | gzip -9 > der.gz
+  yubico-piv-tool -s 9c -i der.gz -K GZIP -a import-cert
+
 Change the management key used for administrative authentication:
 
    yubico-piv-tool -n 0807605403020108070605040302010807060504030201 \\


### PR DESCRIPTION
This could be more sophisticated — it could automatically compress
certificates if they are too large, instead of expecting the user to do
so manually. But this is a good start.
