### PR TITLE
Fixed error when parameters in unblock-pin

### DIFF
--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -1358,9 +1358,10 @@ int main(int argc, char *argv[]) {
             ret = EXIT_FAILURE;
           }
         } else {
-          fprintf(stderr, "The %s action needs a pin (-P) and a new-pin (-N).\n",
+          fprintf(stderr, "The %s action needs a %s (-P) and a new-pin (-N).\n",
               action == action_arg_changeMINUS_pin ? "change-pin" :
-              action == action_arg_changeMINUS_puk ? "change-puk" : "unblock-pin");
+              action == action_arg_changeMINUS_puk ? "change-puk" : "unblock-pin",
+              action == action_arg_unblockMINUS_pin ? "puk" : "pin");
           ret = EXIT_FAILURE;
         }
         break;


### PR DESCRIPTION
when unblock-pin action is called without -P and -N parameter, the wrong
error is returned, saying that -P should be a pin, whereas in this
action it is a puk.

**WRONG**

    $ yubico-piv-tool -a unblock-pin                      
    The unblock-pin action needs a pin (-P) and a new-pin (-N).

**CORRECT**

    $ yubico-piv-tool -a unblock-pin                      
    The unblock-pin action needs a puk (-P) and a new-pin (-N).
