### PR TITLE
Query for PIN/PUK/mgmt-key if not supplied on command line

### DIFF
--- a/tool/util.h
+++ b/tool/util.h
@@ -48,5 +48,6 @@ int get_object_id(enum enum_slot slot);
 bool set_component_with_len(unsigned char**, const BIGNUM*, int);
 bool prepare_rsa_signature(const unsigned char*, unsigned int, unsigned char*,
     unsigned int*, int);
+bool read_pw(const char*, char*, size_t, int);
 
 #endif


### PR DESCRIPTION
Do not force a user to specify the PIN/PUK/mgmt-key on the command line.
Instead, query the user to supply them through stdin when required for
the requested operation.  This is both more user friendly and more
secure, since the secrets do not end up in the shell history and/or
visible to shoulder-surfers on the terminal.