### PR TITLE
Update ykcs11.c

### DIFF
--- a/ykcs11/ykcs11.c
+++ b/ykcs11/ykcs11.c
@@ -731,8 +731,8 @@ CK_DEFINE_FUNCTION(CK_RV, C_Login)(
     return CKR_SESSION_HANDLE_INVALID;
   }
 
-  if ((session.info.flags & CKF_RW_SESSION) == 0) { // TODO: make macros for these?
-    DBG("Tried to log-in to a read-only session");
+  if (userType == CKU_SO && (session.info.flags & CKF_RW_SESSION) == 0) { // TODO: make macros for these?
+    DBG("Tried to log-in SO user to a read-only session");
     return CKR_SESSION_READ_ONLY_EXISTS;
   }
 


### PR DESCRIPTION
According to PKCS11 spec CKR_SESSION_READ_ONLY_EXISTS should only be returned by C_Login when SO user is logging in.

From spec:
If the application calling C_Login has a R/O session open with the token, then it will be unable to log the SO into a session (see [PKCS11-UG] for further details).  An attempt to do this will result in the error code CKR_SESSION_READ_ONLY_EXISTS.