### PR TITLE
Add import/export of CHUID

### DIFF
--- a/lib/ykpiv.h
+++ b/lib/ykpiv.h
@@ -5,15 +5,15 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  *   * Redistributions of source code must retain the above copyright
  *     notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   * Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -205,6 +205,12 @@ extern "C"
 
 #define YKPIV_IS_EC(a) ((a == YKPIV_ALGO_ECCP256 || a == YKPIV_ALGO_ECCP384))
 #define YKPIV_IS_RSA(a) ((a == YKPIV_ALGO_RSA1024 || a == YKPIV_ALGO_RSA2048))
+
+#define YKPIV_CHUID_BEGIN "-----BEGIN CHUID-----"
+#define YKPIV_CHUID_END   "-----END CHUID-----"
+
+#define YKPIV_CHUID_MAX 3072
+#define YKPIV_BASE64_ENCODED_CHUID_MAX 4096+1
 
 #ifdef __cplusplus
 }

--- a/tool/cmdline.ggo
+++ b/tool/cmdline.ggo
@@ -1,18 +1,18 @@
 # Copyright (c) 2014-2015 Yubico AB
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
 # met:
-# 
+#
 #   * Redistributions of source code must retain the above copyright
 #     notice, this list of conditions and the following disclaimer.
-# 
+#
 #   * Redistributions in binary form must reproduce the above
 #     copyright notice, this list of conditions and the following
 #     disclaimer in the documentation and/or other materials provided
 #     with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,7 +32,8 @@ option "action" a "Action to take" values="version","generate","set-mgm-key",
        "reset","pin-retries","import-key","import-certificate","set-chuid",
        "request-certificate","verify-pin","change-pin","change-puk","unblock-pin",
        "selfsign-certificate","delete-certificate","read-certificate","status",
-       "test-signature","test-decipher","list-readers","set-ccc" enum multiple
+       "test-signature","test-decipher","list-readers","set-ccc","export-chuid",
+       "import-chuid" enum multiple
 text   "
        Multiple actions may be given at once and will be executed in order
        for example --action=verify-pin --action=request-certificate\n"


### PR DESCRIPTION
Support for exporting and importing a CHUID object, signed or unsigned, as requested in #48  

Still need an external tool to sign a CHUID and create a CHUID based on input (FASC-N, GUID, expire, etc.)