### PR TITLE
Add options for configuring self-signed certs.

### DIFF
--- a/tool/cmdline.ggo
+++ b/tool/cmdline.ggo
@@ -57,6 +57,7 @@ option "subject" S "The subject to use for certificate request" string optional
 text   "
        The subject must be written as:
        /CN=host.example.com/OU=test/O=example.com/\n"
+option "serial" - "Serial number of the self-signed certificate" int optional default="1"
 option "valid-days" - "Time (in days) until the self-signed certificate expires" int optional default="365"
 option "pin" P "Pin/puk code for verification" string optional
 option "new-pin" N "New pin/puk code for changing" string optional dependon="pin"

--- a/tool/cmdline.ggo
+++ b/tool/cmdline.ggo
@@ -57,6 +57,7 @@ option "subject" S "The subject to use for certificate request" string optional
 text   "
        The subject must be written as:
        /CN=host.example.com/OU=test/O=example.com/\n"
+option "valid-days" - "Time (in days) until the self-signed certificate expires" int optional default="365"
 option "pin" P "Pin/puk code for verification" string optional
 option "new-pin" N "New pin/puk code for changing" string optional dependon="pin"
 option "pin-policy" - "Set pin policy for action generate or import-key" values="never","once","always" enum optional

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -781,7 +781,7 @@ request_out:
 
 static bool selfsign_certificate(ykpiv_state *state, enum enum_key_format key_format,
     const char *input_file_name, const char *slot, char *subject, enum enum_hash hash,
-    const char *output_file_name) {
+    const int validDays, const char *output_file_name) {
   FILE *input_file = NULL;
   FILE *output_file = NULL;
   bool ret = false;
@@ -855,7 +855,7 @@ static bool selfsign_certificate(ykpiv_state *state, enum enum_key_format key_fo
     fprintf(stderr, "Failed to set certificate notBefore.\n");
     goto selfsign_out;
   }
-  if(!X509_gmtime_adj(X509_get_notAfter(x509), 31536000L)) {
+  if(!X509_gmtime_adj(X509_get_notAfter(x509), 60L * 60L * 24L * validDays)) {
     fprintf(stderr, "Failed to set certificate notAfter.\n");
     goto selfsign_out;
   }
@@ -1986,7 +1986,7 @@ int main(int argc, char *argv[]) {
       case action_arg_selfsignMINUS_certificate:
         if(selfsign_certificate(state, args_info.key_format_arg, args_info.input_arg,
               args_info.slot_orig, args_info.subject_arg, args_info.hash_arg,
-              args_info.output_arg) == false) {
+              args_info.valid_days_arg, args_info.output_arg) == false) {
           ret = EXIT_FAILURE;
         } else {
           fprintf(stderr, "Successfully generated a new self signed certificate.\n");

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -781,7 +781,7 @@ request_out:
 
 static bool selfsign_certificate(ykpiv_state *state, enum enum_key_format key_format,
     const char *input_file_name, const char *slot, char *subject, enum enum_hash hash,
-    const int validDays, const char *output_file_name) {
+    const int serial, const int validDays, const char *output_file_name) {
   FILE *input_file = NULL;
   FILE *output_file = NULL;
   bool ret = false;
@@ -847,7 +847,7 @@ static bool selfsign_certificate(ykpiv_state *state, enum enum_key_format key_fo
     fprintf(stderr, "Failed to set the certificate public key.\n");
     goto selfsign_out;
   }
-  if(!ASN1_INTEGER_set(X509_get_serialNumber(x509), 1)) {
+  if(!ASN1_INTEGER_set(X509_get_serialNumber(x509), serial)) {
     fprintf(stderr, "Failed to set certificate serial.\n");
     goto selfsign_out;
   }
@@ -1986,7 +1986,8 @@ int main(int argc, char *argv[]) {
       case action_arg_selfsignMINUS_certificate:
         if(selfsign_certificate(state, args_info.key_format_arg, args_info.input_arg,
               args_info.slot_orig, args_info.subject_arg, args_info.hash_arg,
-              args_info.valid_days_arg, args_info.output_arg) == false) {
+              args_info.serial_arg, args_info.valid_days_arg,
+              args_info.output_arg) == false) {
           ret = EXIT_FAILURE;
         } else {
           fprintf(stderr, "Successfully generated a new self signed certificate.\n");

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -781,7 +781,7 @@ request_out:
 
 static bool selfsign_certificate(ykpiv_state *state, enum enum_key_format key_format,
     const char *input_file_name, const char *slot, char *subject, enum enum_hash hash,
-    const int serial, const int validDays, const char *output_file_name) {
+    int serial, int validDays, const char *output_file_name) {
   FILE *input_file = NULL;
   FILE *output_file = NULL;
   bool ret = false;


### PR DESCRIPTION
Adds `--valid-days` and `--serial` parameters that configure the expiration (`notAfter`) and serial of self-signed certificates generated using the `selfsign-certificate` action.

#### Example use:
```
$ yubico-piv-tool -a verify-pin -P 123456 -a selfsign-certificate -s 9a -S "/CN=Yubikey Token/" -i public.pem -o cert.pem --valid-days 10 --serial 123456789
Successfully verified PIN.
Successfully generated a new self signed certificate.
$ openssl x509 -noout -text -in cert.pem
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 123456789 (0x75bcd15)
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: CN=Yubikey Token
        Validity
            Not Before: Feb 10 23:44:08 2016 GMT
            Not After : Feb 20 23:44:08 2016 GMT
        Subject: CN=Yubikey Token
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
            EC Public Key:
                pub:
                    04:bb:2e:78:2b:ee:14:1e:f7:5a:9f:d7:ae:53:00:
                    ee:d5:11:9b:f6:bb:14:da:bf:d7:41:0b:55:79:b5:
                    c0:3c:0b:44:f5:59:d9:e8:97:b3:2a:37:98:1b:be:
                    c7:a8:a5:23:7a:60:7b:69:63:0e:87:5f:96:75:00:
                    eb:f0:45:9f:4f
                ASN1 OID: prime256v1
    Signature Algorithm: ecdsa-with-SHA256
        30:45:02:21:00:f9:b9:4e:04:6f:31:d8:03:3a:f8:13:bd:0b:
        7f:b0:9f:f1:e6:84:25:af:4c:12:29:2e:05:53:65:f3:ce:9b:
        c9:02:20:6c:32:a0:f4:61:84:01:c4:16:f9:9c:40:52:64:ed:
        53:78:95:5c:6e:d2:35:19:56:ee:eb:c7:e5:a0:71:87:95
```