### PR TITLE
Replace magic number for status word by constants

### DIFF
--- a/lib/ykpiv.h
+++ b/lib/ykpiv.h
@@ -189,6 +189,14 @@ extern "C"
 #define YKPIV_INS_GET_DATA 0xcb
 #define YKPIV_INS_PUT_DATA 0xdb
 
+/* sw is status words, see NIST special publication 800-73-4, section 5.6 */
+#define SW_SUCCESS 0x9000
+#define SW_ERR_SECURITY_STATUS 0x6982
+#define SW_ERR_AUTH_BLOCKED 0x6983
+#define SW_ERR_INCORRECT_PARAM 0x6a80
+/* this is a custom sw for yubikey */
+#define SW_ERR_INCORRECT_SLOT 0x6b00
+
   /* Yubico vendor specific instructions */
 #define YKPIV_INS_SET_MGMKEY 0xff
 #define YKPIV_INS_IMPORT_KEY 0xfe

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -168,11 +168,11 @@ static bool generate_key(ykpiv_state *state, const char *slot,
         &recv_len, &sw) != YKPIV_OK) {
     fprintf(stderr, "Failed to communicate.\n");
     goto generate_out;
-  } else if(sw != 0x9000) {
+  } else if(sw != SW_SUCCESS) {
     fprintf(stderr, "Failed to generate new key (");
-    if(sw == 0x6b00) {
+    if(sw == SW_ERR_INCORRECT_SLOT) {
       fprintf(stderr, "slot not supported?)\n");
-    } else if(sw == 0x6a80) {
+    } else if(sw == SW_ERR_INCORRECT_PARAM) {
       if(pin_policy != pin_policy__NULL) {
         fprintf(stderr, "pin policy not supported?)\n");
       } else if(touch_policy != touch_policy__NULL) {
@@ -297,7 +297,7 @@ static bool reset(ykpiv_state *state) {
   /* note: the reset function is only available when both pins are blocked. */
   if(ykpiv_transfer_data(state, templ, NULL, 0, data, &recv_len, &sw) != YKPIV_OK) {
     return false;
-  } else if(sw == 0x9000) {
+  } else if(sw == SW_SUCCESS) {
     return true;
   }
   return false;
@@ -320,7 +320,7 @@ static bool set_pin_retries(ykpiv_state *state, int pin_retries, int puk_retries
 
   if(ykpiv_transfer_data(state, templ, NULL, 0, data, &recv_len, &sw) != YKPIV_OK) {
     return false;
-  } else if(sw == 0x9000) {
+  } else if(sw == SW_SUCCESS) {
     return true;
   }
   return false;
@@ -1676,7 +1676,7 @@ static bool attest(ykpiv_state *state, const char *slot,
   if(ykpiv_transfer_data(state, templ, NULL, 0, data, &len, &sw) != YKPIV_OK) {
     fprintf(stderr, "Failed to communicate.\n");
     goto attest_out;
-  } else if(sw != 0x9000) {
+  } else if(sw != SW_SUCCESS) {
     fprintf(stderr, "Failed to attest key.\n");
     goto attest_out;
   }


### PR DESCRIPTION
Most come from NIST special publication 800-73-4, section 5.6,
except one which I assume to be a custom one for yubikey.