### PR TITLE
OopenSSL 1.1.0 compatibility

### DIFF
--- a/lib/ykpiv.c
+++ b/lib/ykpiv.c
@@ -478,7 +478,7 @@ ykpiv_rc ykpiv_authenticate(ykpiv_state *state, unsigned const char *key) {
     dataptr += 8;
     *dataptr++ = 0x81;
     *dataptr++ = 8;
-    if(RAND_pseudo_bytes(dataptr, 8) == -1) {
+    if(RAND_bytes(dataptr, 8) == -1) {
       if(state->verbose) {
   fprintf(stderr, "Failed getting randomness for authentication.\n");
       }

--- a/tool/Makefile.am
+++ b/tool/Makefile.am
@@ -40,7 +40,7 @@ noinst_LTLIBRARIES = libpiv_cmd.la libpiv_util.la
 libpiv_cmd_la_SOURCES = cmdline.ggo cmdline.c cmdline.h
 libpiv_cmd_la_CFLAGS =
 
-libpiv_util_la_SOURCES = util.c util.h
+libpiv_util_la_SOURCES = util.c util.h openssl-compat.c
 libpiv_util_la_LIBADD = $(top_builddir)/lib/libykpiv.la $(OPENSSL_LIBS)
 
 cmdline.c cmdline.h: cmdline.ggo Makefile.am $(top_srcdir)/configure.ac

--- a/tool/Makefile.am
+++ b/tool/Makefile.am
@@ -40,7 +40,7 @@ noinst_LTLIBRARIES = libpiv_cmd.la libpiv_util.la
 libpiv_cmd_la_SOURCES = cmdline.ggo cmdline.c cmdline.h
 libpiv_cmd_la_CFLAGS =
 
-libpiv_util_la_SOURCES = util.c util.h openssl-compat.c
+libpiv_util_la_SOURCES = util.c util.h openssl-compat.c openssl-compat.h
 libpiv_util_la_LIBADD = $(top_builddir)/lib/libykpiv.la $(OPENSSL_LIBS)
 
 cmdline.c cmdline.h: cmdline.ggo Makefile.am $(top_srcdir)/configure.ac

--- a/tool/openssl-compat.c
+++ b/tool/openssl-compat.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+#include <string.h>
+#include <openssl/engine.h>
+
+
+int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
+{
+    /* If the fields n and e in r are NULL, the corresponding input
+     * parameters MUST be non-NULL for n and e.  d may be
+     * left NULL (in case only the public key is used).
+     */
+    if ((r->n == NULL && n == NULL)
+        || (r->e == NULL && e == NULL))
+        return 0;
+
+    if (n != NULL) {
+        BN_free(r->n);
+        r->n = n;
+    }
+    if (e != NULL) {
+        BN_free(r->e);
+        r->e = e;
+    }
+    if (d != NULL) {
+        BN_free(r->d);
+        r->d = d;
+    }
+
+    return 1;
+}
+
+void RSA_get0_key(const RSA *r,
+                  const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
+{
+    if (n != NULL)
+        *n = r->n;
+    if (e != NULL)
+        *e = r->e;
+    if (d != NULL)
+        *d = r->d;
+}
+
+#endif /* OPENSSL_VERSION_NUMBER */

--- a/tool/openssl-compat.c
+++ b/tool/openssl-compat.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/opensslv.h>
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 #include <string.h>
@@ -48,6 +49,35 @@ void RSA_get0_key(const RSA *r,
         *e = r->e;
     if (d != NULL)
         *d = r->d;
+}
+
+void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q)
+{
+    if (p != NULL)
+        *p = r->p;
+    if (q != NULL)
+        *q = r->q;
+}
+
+void RSA_get0_crt_params(const RSA *r,
+                         const BIGNUM **dmp1, const BIGNUM **dmq1,
+                         const BIGNUM **iqmp)
+{
+    if (dmp1 != NULL)
+        *dmp1 = r->dmp1;
+    if (dmq1 != NULL)
+        *dmq1 = r->dmq1;
+    if (iqmp != NULL)
+        *iqmp = r->iqmp;
+}
+
+void X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
+                   ASN1_OCTET_STRING **pdigest)
+{
+    if (palg)
+        *palg = sig->algor;
+    if (pdigest)
+        *pdigest = sig->digest;
 }
 
 #endif /* OPENSSL_VERSION_NUMBER */

--- a/tool/openssl-compat.c
+++ b/tool/openssl-compat.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/opensslv.h>
+#include "openssl-compat.h"
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 #include <string.h>

--- a/tool/openssl-compat.h
+++ b/tool/openssl-compat.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 1995-2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef LIBCRYPTO_COMPAT_H
+#define LIBCRYPTO_COMPAT_H
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+#include <openssl/rsa.h>
+#include <openssl/dsa.h>
+#include <openssl/ecdsa.h>
+#include <openssl/dh.h>
+#include <openssl/evp.h>
+
+int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
+void RSA_get0_key(const RSA *r,
+                  const BIGNUM **n, const BIGNUM **e, const BIGNUM **d);
+
+#endif /* OPENSSL_VERSION_NUMBER */
+#endif /* LIBCRYPTO_COMPAT_H */
+

--- a/tool/openssl-compat.h
+++ b/tool/openssl-compat.h
@@ -17,10 +17,17 @@
 #include <openssl/ecdsa.h>
 #include <openssl/dh.h>
 #include <openssl/evp.h>
+#include <openssl/x509.h>
 
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
 void RSA_get0_key(const RSA *r,
                   const BIGNUM **n, const BIGNUM **e, const BIGNUM **d);
+void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q);
+void RSA_get0_crt_params(const RSA *r,
+                         const BIGNUM **dmp1, const BIGNUM **dmq1,
+                         const BIGNUM **iqmp);
+void X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
+                   ASN1_OCTET_STRING **pdigest);
 
 #endif /* OPENSSL_VERSION_NUMBER */
 #endif /* LIBCRYPTO_COMPAT_H */

--- a/tool/openssl-compat.h
+++ b/tool/openssl-compat.h
@@ -10,6 +10,7 @@
 #ifndef LIBCRYPTO_COMPAT_H
 #define LIBCRYPTO_COMPAT_H
 
+#include <openssl/opensslv.h>
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 #include <openssl/rsa.h>

--- a/tool/util.c
+++ b/tool/util.c
@@ -438,23 +438,23 @@ bool set_component(unsigned char *in_ptr, const BIGNUM *bn, int element_len) {
 }
 
 bool prepare_rsa_signature(const unsigned char *in, unsigned int in_len, unsigned char *out, unsigned int *out_len, int nid) {
-  X509_SIG digestInfo;
-  X509_ALGOR algor;
+  X509_SIG *digestInfo;
+  X509_ALGOR *algor;
   ASN1_TYPE parameter;
-  ASN1_OCTET_STRING digest;
+  ASN1_OCTET_STRING *digest;
   unsigned char data[1024];
 
   memcpy(data, in, in_len);
 
-  digestInfo.algor = &algor;
-  digestInfo.algor->algorithm = OBJ_nid2obj(nid);
-  digestInfo.algor->parameter = &parameter;
-  digestInfo.algor->parameter->type = V_ASN1_NULL;
-  digestInfo.algor->parameter->value.ptr = NULL;
-  digestInfo.digest = &digest;
-  digestInfo.digest->data = data;
-  digestInfo.digest->length = (int)in_len;
-  *out_len = (unsigned int)i2d_X509_SIG(&digestInfo, &out);
+  digestInfo = X509_SIG_new();
+  X509_SIG_getm(digestInfo, &algor, &digest);
+  algor = X509_ALGOR_new();
+  X509_ALGOR_set0(algor, OBJ_nid2obj(nid), V_ASN1_NULL, &parameter);
+  parameter.type = V_ASN1_NULL;
+  parameter.value.ptr = NULL;
+  digest->data = data;
+  digest->length = (int)in_len;
+  *out_len = (unsigned int)i2d_X509_SIG(digestInfo, &out);
   return true;
 }
 
@@ -637,7 +637,7 @@ int SSH_write_X509(FILE *fp, X509 *x) {
     return ret;
   }
 
-  switch (pkey->type) {
+  switch (EVP_PKEY_id(pkey)) {
   case EVP_PKEY_RSA:
   case EVP_PKEY_RSA2: {
     RSA *rsa;

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -116,6 +116,7 @@ static bool sign_data(ykpiv_state *state, const unsigned char *in, size_t len, u
   return false;
 }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 static int ec_key_ex_data_idx = -1;
 
 struct internal_key {
@@ -148,7 +149,6 @@ yk_ec_meth_sign(int type, const unsigned char *dgst, int dlen,
   return 1;
 }
 
-#if OPENSSL_VERSION_NUMBER >= 10100000L
 static int
 wrap_public_key(ykpiv_state *state, int algorithm, EVP_PKEY *public_key,
     int key)
@@ -801,7 +801,7 @@ static bool request_certificate(ykpiv_state *state, enum enum_key_format key_for
     goto request_out;
   }
 
-#if OPENSSL_VERSION_NUMBER < 10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   memcpy(digest, oid, oid_len);
   /* XXX: this should probably use X509_REQ_digest() but that's buggy */
   if(!ASN1_item_digest(ASN1_ITEM_rptr(X509_REQ_INFO), md, req->req_info,
@@ -864,7 +864,7 @@ request_out:
     EVP_PKEY_free(public_key);
   }
   if(req) {
-#if OPENSSL_VERSION_NUMBER < 10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if(req->sig_alg->parameter) {
       req->sig_alg->parameter = NULL;
     }
@@ -997,7 +997,7 @@ static bool selfsign_certificate(ykpiv_state *state, enum enum_key_format key_fo
   if(nid == 0) {
     goto selfsign_out;
   }
-#if OPENSSL_VERSION_NUMBER < 10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   if(YKPIV_IS_RSA(algorithm)) {
     signinput = digest;
     len = oid_len + md_len;
@@ -1054,7 +1054,7 @@ selfsign_out:
     fclose(output_file);
   }
   if(x509) {
-#if OPENSSL_VERSION_NUMBER < 10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if(x509->sig_alg->parameter) {
       x509->sig_alg->parameter = NULL;
       x509->cert_info->signature->parameter = NULL;

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -411,39 +411,43 @@ static bool import_key(ykpiv_state *state, enum enum_key_format key_format,
       unsigned char dmp1[128];
       unsigned char dmq1[128];
       unsigned char iqmp[128];
+      const BIGNUM *bn_e, *bn_p, *bn_q, *bn_dmp1, *bn_dmq1, *bn_iqmp;
 
       int element_len = 128;
       if(algorithm == YKPIV_ALGO_RSA1024) {
         element_len = 64;
       }
 
-      if((set_component(e, rsa_private_key->e, 3) == false) ||
+      RSA_get0_key(rsa_private_key, NULL, &bn_e, NULL);
+      RSA_get0_factors(rsa_private_key, &bn_p, &bn_q);
+      RSA_get0_crt_params(rsa_private_key, &bn_dmp1, &bn_dmq1, &bn_iqmp);
+      if((set_component(e, bn_e, 3) == false) ||
          !(e[0] == 0x01 && e[1] == 0x00 && e[2] == 0x01)) {
         fprintf(stderr, "Invalid public exponent for import (only 0x10001 supported)\n");
         goto import_out;
       }
 
-      if(set_component(p, rsa_private_key->p, element_len) == false) {
+      if(set_component(p, bn_p, element_len) == false) {
         fprintf(stderr, "Failed setting p component.\n");
         goto import_out;
       }
 
-      if(set_component(q, rsa_private_key->q, element_len) == false) {
+      if(set_component(q, bn_q, element_len) == false) {
         fprintf(stderr, "Failed setting q component.\n");
         goto import_out;
       }
 
-      if(set_component(dmp1, rsa_private_key->dmp1, element_len) == false) {
+      if(set_component(dmp1, bn_dmp1, element_len) == false) {
         fprintf(stderr, "Failed setting dmp1 component.\n");
         goto import_out;
       }
 
-      if(set_component(dmq1, rsa_private_key->dmq1, element_len) == false) {
+      if(set_component(dmq1, bn_dmq1, element_len) == false) {
         fprintf(stderr, "Failed setting dmq1 component.\n");
         goto import_out;
       }
 
-      if(set_component(iqmp, rsa_private_key->iqmp, element_len) == false) {
+      if(set_component(iqmp, bn_iqmp, element_len) == false) {
         fprintf(stderr, "Failed setting iqmp component.\n");
         goto import_out;
       }

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -645,7 +645,7 @@ static bool set_dataobject(ykpiv_state *state, int verbose, int type) {
     id = YKPIV_OBJ_CAPABILITY;
   }
   memcpy(obj, tmpl, len);
-  if(RAND_pseudo_bytes(obj + offs, rand_len) == -1) {
+  if(RAND_bytes(obj + offs, rand_len) == -1) {
     fprintf(stderr, "error: no randomness.\n");
     return false;
   }
@@ -1457,7 +1457,7 @@ static bool test_signature(ykpiv_state *state, enum enum_slot slot,
   {
     unsigned char rand[128];
     EVP_MD_CTX *mdctx;
-    if(RAND_pseudo_bytes(rand, 128) == -1) {
+    if(RAND_bytes(rand, 128) == -1) {
       fprintf(stderr, "error: no randomness.\n");
       return false;
     }
@@ -1604,7 +1604,7 @@ static bool test_decipher(ykpiv_state *state, enum enum_slot slot,
       size_t len2 = sizeof(data);
       RSA *rsa = EVP_PKEY_get1_RSA(pubkey);
 
-      if(RAND_pseudo_bytes(secret, sizeof(secret)) == -1) {
+      if(RAND_bytes(secret, sizeof(secret)) == -1) {
         fprintf(stderr, "error: no randomness.\n");
         ret = false;
         goto decipher_out;

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -42,6 +42,7 @@
 #include <windows.h>
 #endif
 
+#include "openssl-compat.h"
 #include <openssl/des.h>
 #include <openssl/pem.h>
 #include <openssl/pkcs12.h>
@@ -234,8 +235,7 @@ static bool generate_key(ykpiv_state *state, const char *slot,
         goto generate_out;
       }
 
-      rsa->n = bignum_n;
-      rsa->e = bignum_e;
+      RSA_set0_key(rsa, bignum_n, bignum_e, NULL);
       EVP_PKEY_set1_RSA(public_key, rsa);
     } else if(algorithm == algorithm_arg_ECCP256 || algorithm == algorithm_arg_ECCP384) {
       EC_GROUP *group;

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -148,6 +148,7 @@ yk_ec_meth_sign(int type, const unsigned char *dgst, int dlen,
   return 1;
 }
 
+#if OPENSSL_VERSION_NUMBER >= 10100000L
 static int
 wrap_public_key(ykpiv_state *state, int algorithm, EVP_PKEY *public_key,
     int key)
@@ -171,6 +172,7 @@ wrap_public_key(ykpiv_state *state, int algorithm, EVP_PKEY *public_key,
   }
   return 0;
 }
+#endif
 
 static bool generate_key(ykpiv_state *state, const char *slot,
     enum enum_algorithm algorithm, const char *output_file_name,

--- a/ykcs11/openssl_utils.c
+++ b/ykcs11/openssl_utils.c
@@ -165,6 +165,7 @@ CK_RV do_create_empty_cert(CK_BYTE_PTR in, CK_ULONG in_len, CK_BBOOL is_rsa,
   X509_set_notBefore(cert, tm);
   X509_set_notAfter(cert, tm);
 
+#if OPENSSL_VERSION_NUMBER < 10100000L
   // Manually set the signature algorithms.
   // OpenSSL 1.0.1i complains about empty DER fields
   // 8 => md5WithRsaEncryption
@@ -174,6 +175,7 @@ CK_RV do_create_empty_cert(CK_BYTE_PTR in, CK_ULONG in_len, CK_BBOOL is_rsa,
   // Manually set a signature (same reason as before)
   ASN1_BIT_STRING_set_bit(cert->signature, 8, 1);
   ASN1_BIT_STRING_set(cert->signature, "\x00", 1);
+#endif
 
   len = i2d_X509(cert, NULL);
   if (len < 0)

--- a/ykcs11/openssl_utils.c
+++ b/ykcs11/openssl_utils.c
@@ -476,16 +476,20 @@ CK_RV do_get_public_key(EVP_PKEY *key, CK_BYTE_PTR data, CK_ULONG_PTR len) {
 CK_RV do_encode_rsa_public_key(ykcs11_rsa_key_t **key, CK_BYTE_PTR modulus,
           CK_ULONG mlen, CK_BYTE_PTR exponent, CK_ULONG elen) {
   ykcs11_rsa_key_t *k;
+  BIGNUM *k_n = NULL, *k_e = NULL;
   if (modulus == NULL || exponent == NULL)
     return CKR_ARGUMENTS_BAD;
 
   if ((k = RSA_new()) == NULL)
     return CKR_HOST_MEMORY;
 
-  if ((k->n = BN_bin2bn(modulus, mlen, NULL)) == NULL)
+  if ((k_n = BN_bin2bn(modulus, mlen, NULL)) == NULL)
     return CKR_FUNCTION_FAILED;
 
-  if ((k->e = BN_bin2bn(exponent, elen, NULL)) == NULL)
+  if ((k_e = BN_bin2bn(exponent, elen, NULL)) == NULL)
+    return CKR_FUNCTION_FAILED;
+
+  if (RSA_set0_key(k, k_n, k_e, NULL) == 0)
     return CKR_FUNCTION_FAILED;
 
   *key = k;

--- a/ykcs11/tests/ykcs11_tests.c
+++ b/ykcs11/tests/ykcs11_tests.c
@@ -259,7 +259,7 @@ static void test_login() {
 
 }
 
-#if OPENSSL_VERSION_NUMBER >= 10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 static int bogus_sign(int dtype, const unsigned char *m, unsigned int m_length,
                unsigned char *sigret, unsigned int *siglen, const RSA *rsa) {
   sigret = malloc(1);
@@ -370,7 +370,7 @@ static void test_import_and_sign_all_10() {
   X509_set_notBefore(cert, tm);
   X509_set_notAfter(cert, tm);
 
-#if OPENSSL_VERSION_NUMBER < 10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   cert->sig_alg->algorithm = OBJ_nid2obj(8);
   cert->cert_info->signature->algorithm = OBJ_nid2obj(8);
 
@@ -568,7 +568,7 @@ static void test_import_and_sign_all_10_RSA() {
   X509_set_notBefore(cert, tm);
   X509_set_notAfter(cert, tm);
 
-#if OPENSSL_VERSION_NUMBER < 10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   /* putting bogus data to signature to make some checks happy */
   cert->sig_alg->algorithm = OBJ_nid2obj(8);
   cert->cert_info->signature->algorithm = OBJ_nid2obj(8);

--- a/ykcs11/tests/ykcs11_tests.c
+++ b/ykcs11/tests/ykcs11_tests.c
@@ -466,6 +466,7 @@ static void test_import_and_sign_all_10_RSA() {
   CK_BYTE_PTR s_ptr;
   CK_ULONG    r_len;
   CK_ULONG    s_len;
+  const BIGNUM *bp, *bq, *biqmp, *bdmp1, *bdmq1;
 
   unsigned char  *px;
 
@@ -508,11 +509,13 @@ static void test_import_and_sign_all_10_RSA() {
 
   asrt(RSA_generate_key_ex(rsak, 1024, e_bn, NULL), 1, "GENERATE RSAK");
 
-  asrt(BN_bn2bin(rsak->p, p), 64, "GET P");
-  asrt(BN_bn2bin(rsak->q, q), 64, "GET Q");
-  asrt(BN_bn2bin(rsak->dmp1, dp), 64, "GET DP");
-  asrt(BN_bn2bin(rsak->dmq1, dp), 64, "GET DQ");
-  asrt(BN_bn2bin(rsak->iqmp, qinv), 64, "GET QINV");
+  RSA_get0_factors(rsak, &bp, &bq);
+  RSA_get0_crt_params(rsak, &bdmp1, &bdmq1, &biqmp);
+  asrt(BN_bn2bin(bp, p), 64, "GET P");
+  asrt(BN_bn2bin(bq, q), 64, "GET Q");
+  asrt(BN_bn2bin(bdmp1, dp), 64, "GET DP");
+  asrt(BN_bn2bin(bdmq1, dp), 64, "GET DQ");
+  asrt(BN_bn2bin(biqmp, qinv), 64, "GET QINV");
 
 
 

--- a/ykcs11/tests/ykcs11_tests.c
+++ b/ykcs11/tests/ykcs11_tests.c
@@ -371,7 +371,7 @@ static void test_import_and_sign_all_10() {
   for (i = 0; i < 24; i++) {
     for (j = 0; j < 10; j++) {
 
-      if(RAND_pseudo_bytes(some_data, sizeof(some_data)) == -1)
+      if(RAND_bytes(some_data, sizeof(some_data)) == -1)
         exit(EXIT_FAILURE);
 
       asrt(funcs->C_Login(session, CKU_USER, "123456", 6), CKR_OK, "Login USER");
@@ -562,7 +562,7 @@ static void test_import_and_sign_all_10_RSA() {
   for (i = 0; i < 24; i++) {
     for (j = 0; j < 10; j++) {
 
-      if(RAND_pseudo_bytes(some_data, sizeof(some_data)) == -1)
+      if(RAND_bytes(some_data, sizeof(some_data)) == -1)
         exit(EXIT_FAILURE);
 
       asrt(funcs->C_Login(session, CKU_USER, "123456", 6), CKR_OK, "Login USER");


### PR DESCRIPTION
Update 2017-11-14: Resolves  #104. Tested with latest Yubikey 4 with hardware tests, provisioning new key and selfsigning certificates.