### PR TITLE
Added checks to allow building against LibreSSL

### DIFF
--- a/tool/openssl-compat.c
+++ b/tool/openssl-compat.c
@@ -8,7 +8,7 @@
  */
 
 #include "openssl-compat.h"
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
 
 #include <string.h>
 #include <openssl/engine.h>
@@ -80,4 +80,4 @@ void X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
         *pdigest = sig->digest;
 }
 
-#endif /* OPENSSL_VERSION_NUMBER */
+#endif /* OPENSSL_VERSION_NUMBER || LIBRESSL_VERSION_NUMBER */

--- a/tool/openssl-compat.h
+++ b/tool/openssl-compat.h
@@ -13,7 +13,7 @@
 #ifndef _WINDOWS
 
 #include <openssl/opensslv.h>
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
 
 #include <openssl/rsa.h>
 #include <openssl/dsa.h>
@@ -33,5 +33,5 @@ void X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
                    ASN1_OCTET_STRING **pdigest);
 
 #endif /* _WINDOWS */
-#endif /* OPENSSL_VERSION_NUMBER */
+#endif /* OPENSSL_VERSION_NUMBER || LIBRESSL_VERSION_NUMBER */
 #endif /* LIBCRYPTO_COMPAT_H */

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -124,7 +124,7 @@ static bool sign_data(ykpiv_state *state, const unsigned char *in, size_t len, u
   return false;
 }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if !((OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER))
 static int ec_key_ex_data_idx = -1;
 
 struct internal_key {
@@ -688,7 +688,7 @@ static bool request_certificate(ykpiv_state *state, enum enum_key_format key_for
     goto request_out;
   }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
   memcpy(digest, oid, oid_len);
   /* XXX: this should probably use X509_REQ_digest() but that's buggy */
   if(!ASN1_item_digest(ASN1_ITEM_rptr(X509_REQ_INFO), md, req->req_info,
@@ -751,7 +751,7 @@ request_out:
     EVP_PKEY_free(public_key);
   }
   if(req) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
     if(req->sig_alg->parameter) {
       req->sig_alg->parameter = NULL;
     }
@@ -884,7 +884,7 @@ static bool selfsign_certificate(ykpiv_state *state, enum enum_key_format key_fo
   if(nid == 0) {
     goto selfsign_out;
   }
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
   if(YKPIV_IS_RSA(algorithm)) {
     signinput = digest;
     len = oid_len + md_len;
@@ -941,7 +941,7 @@ selfsign_out:
     fclose(output_file);
   }
   if(x509) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
     if(x509->sig_alg->parameter) {
       x509->sig_alg->parameter = NULL;
       x509->cert_info->signature->parameter = NULL;

--- a/ykcs11/openssl_utils.c
+++ b/ykcs11/openssl_utils.c
@@ -165,7 +165,7 @@ CK_RV do_create_empty_cert(CK_BYTE_PTR in, CK_ULONG in_len, CK_BBOOL is_rsa,
   X509_set_notBefore(cert, tm);
   X509_set_notAfter(cert, tm);
 
-#if OPENSSL_VERSION_NUMBER < 10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
   // Manually set the signature algorithms.
   // OpenSSL 1.0.1i complains about empty DER fields
   // 8 => md5WithRsaEncryption

--- a/ykcs11/tests/ykcs11_tests.c
+++ b/ykcs11/tests/ykcs11_tests.c
@@ -274,7 +274,7 @@ static void test_login() {
 
 }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if !((OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER))
 static int bogus_sign(int dtype, const unsigned char *m, unsigned int m_length,
                unsigned char *sigret, unsigned int *siglen, const RSA *rsa) {
   sigret = malloc(1);
@@ -385,7 +385,7 @@ static void test_import_and_sign_all_10() {
   X509_set_notBefore(cert, tm);
   X509_set_notAfter(cert, tm);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
   cert->sig_alg->algorithm = OBJ_nid2obj(8);
   cert->cert_info->signature->algorithm = OBJ_nid2obj(8);
 
@@ -583,7 +583,7 @@ static void test_import_and_sign_all_10_RSA() {
   X509_set_notBefore(cert, tm);
   X509_set_notAfter(cert, tm);
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
   /* putting bogus data to signature to make some checks happy */
   cert->sig_alg->algorithm = OBJ_nid2obj(8);
   cert->cert_info->signature->algorithm = OBJ_nid2obj(8);


### PR DESCRIPTION
Previously, compiling against LibreSSL worked seamlessly due to being API compatible with OpenSSL 1.0.1. This was broken when OpenSSL 1.1.0 support was added due to the OpenSSL version check conflicting with the LibreSSL versioning scheme.

This PR mitigates the problem by checking the LIBRESSL_VERSION_NUMBER macro where applicable.