### PR TITLE
Compiler warnings and compatibility with older check versions

### DIFF
--- a/lib/tests/api.c
+++ b/lib/tests/api.c
@@ -92,6 +92,7 @@ void teardown(void) {
   ck_assert_int_eq(res, YKPIV_OK);
 }
 
+#ifdef HW_TESTS
 START_TEST(test_devicemodel) {
   ykpiv_rc res;
   ykpiv_devmodel model;
@@ -926,6 +927,7 @@ START_TEST(test_pin_cache) {
   ck_assert_int_eq(res, YKPIV_OK);
 }
 END_TEST
+#endif
 
 int destruction_confirmed(void) {
   char *confirmed = getenv("YKPIV_ENV_HWTESTS_CONFIRMED");

--- a/lib/tests/api.c
+++ b/lib/tests/api.c
@@ -272,7 +272,6 @@ static bool set_component(unsigned char *in_ptr, const BIGNUM *bn, int element_l
 static bool prepare_rsa_signature(const unsigned char *in, unsigned int in_len, unsigned char *out, unsigned int *out_len, int nid) {
   X509_SIG *digestInfo;
   X509_ALGOR *algor;
-  ASN1_TYPE parameter;
   ASN1_OCTET_STRING *digest;
   unsigned char data[1024];
 

--- a/lib/tests/api.c
+++ b/lib/tests/api.c
@@ -52,6 +52,10 @@ int destruction_confirmed(void);
 #ifndef ck_assert_mem_eq
 #define ck_assert_mem_eq(a,b,n) ck_assert(memcmp((a), (b), (n)) == 0)
 #endif
+// only defined in libcheck 0.10+ (RHEL7 is still shipping 0.9)
+#ifndef ck_assert_ptr_eq
+#define ck_assert_ptr_eq(a,b) ck_assert((void *)(a) == (void *)(b))
+#endif
 
 ykpiv_state *g_state;
 const uint8_t g_cert[] = {

--- a/lib/util.c
+++ b/lib/util.c
@@ -221,7 +221,6 @@ ykpiv_rc ykpiv_util_list_keys(ykpiv_state *state, uint8_t *key_count, ykpiv_key 
   size_t offset = 0;
   uint8_t buf[CB_BUF_MAX];
   size_t cbBuf = 0;
-  bool transaction = false;
   size_t i = 0;
   size_t cbRealloc = 0;
 
@@ -491,7 +490,6 @@ Cleanup:
 ykpiv_rc ykpiv_util_write_mscmap(ykpiv_state *state, ykpiv_container *containers, size_t n_containers) {
   ykpiv_rc res = YKPIV_OK;
   uint8_t buf[CB_OBJ_MAX];
-  size_t cbBuf = sizeof(buf);
   size_t offset = 0;
   size_t req_len = 0;
   size_t data_len = n_containers * sizeof(ykpiv_container);
@@ -1343,7 +1341,6 @@ static ykpiv_rc _read_certificate(ykpiv_state *state, uint8_t slot, uint8_t *buf
 
 static ykpiv_rc _write_certificate(ykpiv_state *state, uint8_t slot, uint8_t *data, size_t data_len, uint8_t certinfo) {
   uint8_t buf[CB_OBJ_MAX];
-  size_t cbBuf = sizeof(buf);
   int object_id = ykpiv_util_slot_object(slot);
   size_t offset = 0;
   size_t req_len = 0;

--- a/tool/util.c
+++ b/tool/util.c
@@ -336,7 +336,6 @@ bool set_component(unsigned char *in_ptr, const BIGNUM *bn, int element_len) {
 bool prepare_rsa_signature(const unsigned char *in, unsigned int in_len, unsigned char *out, unsigned int *out_len, int nid) {
   X509_SIG *digestInfo;
   X509_ALGOR *algor;
-  ASN1_TYPE parameter;
   ASN1_OCTET_STRING *digest;
   unsigned char data[1024];
 


### PR DESCRIPTION
While trying to build the latest version of `yubico-piv-tool` for EPEL7, I encountered several issues, mostly, the RHEL/CentOS 7 has older version of `check` (`check-0.9.9-5.el7.x86_64`), which does not provide the `ck_assert_ptr_eq`, but it can be simply rewritten to `ck_assert`. Secondly, there showed up some warnings, mostly in context of not running the HW tests at build time.

With these patches, I am able to build the package on both current Fedora and RHEL7 successfully (I did not test the HW_TEST though -- I don't have spare Yubikey at this moment).