### PR TITLE
Improve compatibility with OpenSSL 1.1.0

### DIFF
--- a/tool/util.c
+++ b/tool/util.c
@@ -38,6 +38,7 @@
 #endif
 
 #include "openssl-compat.h"
+#include <openssl/bn.h>
 #include <openssl/evp.h>
 #include <openssl/x509.h>
 #include <openssl/rsa.h>

--- a/ykcs11/openssl_types.h
+++ b/ykcs11/openssl_types.h
@@ -31,6 +31,7 @@
 #ifndef OPENSSL_TYPES_H
 #define OPENSSL_TYPES_H
 
+#include <openssl/bn.h>
 #include <openssl/x509.h>
 #include <openssl/evp.h>
 #include <openssl/rsa.h>


### PR DESCRIPTION
OpenSSL 1.1.0 can be compiled in a variety of compatibility modes. On my machine, OpenSSL 1.1.0 has all compatibility APIs disabled by default.
This PR thus removes/replaces all calls to deprecated APIs when compiling against OpenSSL 1.1.0, and also adds some required headers.

Please review and feel free to comment so I can adjust things. :)