### PR TITLE
lib: make the reader comparison case-insensitive

### DIFF
--- a/lib/ykpiv.c
+++ b/lib/ykpiv.c
@@ -349,7 +349,19 @@ ykpiv_rc ykpiv_connect(ykpiv_state *state, const char *wanted) {
 
   for(reader_ptr = reader_buf; *reader_ptr != '\0'; reader_ptr += strlen(reader_ptr) + 1) {
     if(wanted) {
-      if(!strstr(reader_ptr, wanted)) {
+      char *ptr = reader_ptr;
+      bool found = false;
+      do {
+        if(strlen(ptr) < strlen(wanted)) {
+          break;
+        }
+        if(strncasecmp(ptr, wanted, strlen(wanted)) == 0) {
+          found = true;
+          break;
+        }
+      } while(*ptr++);
+
+      if(found == false) {
         if(state->verbose) {
           fprintf(stderr, "skipping reader '%s' since it doesn't match '%s'.\n", reader_ptr, wanted);
         }


### PR DESCRIPTION
sadly strcasestr is a GNU/BSD extension, not part of posix so we have to
do our own thing here or do different things on different platforms.