### PR TITLE
libykpiv/piv-tool 1.6.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,9 +33,9 @@ AC_CONFIG_MACRO_DIR([m4])
 # Interfaces changed/added/removed:   CURRENT++       REVISION=0
 # Interfaces added:                             AGE++
 # Interfaces removed:                           AGE=0
-AC_SUBST([LT_CURRENT], 5)
-AC_SUBST([LT_REVISION], 5)
-AC_SUBST([LT_AGE], 4)
+AC_SUBST([LT_CURRENT], 6)
+AC_SUBST([LT_REVISION], 0)
+AC_SUBST([LT_AGE], 5)
 
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_SILENT_RULES([yes])
@@ -224,6 +224,7 @@ if test "$gl_gcc_warnings" = yes; then
   nw="$nw -Wconversion"             # Too many warnings for now
   nw="$nw -Wsuggest-attribute=pure" # Is it worth using attributes?
   nw="$nw -Wsuggest-attribute=const" # Is it worth using attributes?
+  nw="$nw -Waggregate-return"       # returning structs shouldn't be a problem
 
   gl_MANYWARN_ALL_GCC([ws])
   gl_MANYWARN_COMPLEMENT(ws, [$ws], [$nw])

--- a/lib/internal.c
+++ b/lib/internal.c
@@ -304,8 +304,11 @@ des_rc des_encrypt(des_key* key, const unsigned char* in, const size_t inlen, un
 
 #else
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
   /* openssl returns void */
   DES_ecb3_encrypt((const_DES_cblock *)in, (DES_cblock*)out, &(key->ks1), &(key->ks2), &(key->ks3), 1);
+#pragma GCC diagnostic pop
 
 #endif
 
@@ -336,8 +339,11 @@ des_rc des_decrypt(des_key* key, const unsigned char* in, const size_t inlen, un
 
 #else
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
   /* openssl returns void */
   DES_ecb3_encrypt((const_DES_cblock*)in, (DES_cblock*)out, &(key->ks1), &(key->ks2), &(key->ks3), 0);
+#pragma GCC diagnostic pop
 
 #endif
 
@@ -400,7 +406,12 @@ bool yk_des_is_weak_key(const unsigned char *key, const size_t cb_key) {
 
   return false;
 #else
+  (void)cb_key; /* unused */
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
   return DES_is_weak_key((const_DES_cblock *)key);
+#pragma GCC diagnostic pop
 #endif
 }
 
@@ -431,7 +442,7 @@ prng_rc _ykpiv_prng_generate(unsigned char *buffer, const size_t cb_req) {
   return rc;
 }
 
-pkcs5_rc pkcs5_pbkdf2_sha1(const unsigned char* password, const size_t cb_password, const unsigned char* salt, const size_t cb_salt, unsigned long long iterations, unsigned char* key, const size_t cb_key) {
+pkcs5_rc pkcs5_pbkdf2_sha1(const uint8_t* password, const size_t cb_password, const uint8_t* salt, const size_t cb_salt, uint64_t iterations, const uint8_t* key, const size_t cb_key) {
   pkcs5_rc rc = PKCS5_OK;
 
 #ifdef _WINDOWS
@@ -459,8 +470,11 @@ pkcs5_rc pkcs5_pbkdf2_sha1(const unsigned char* password, const size_t cb_passwo
 
 #else
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
   /* for some reason openssl always returns 1 for PBKDF2 */
-  PKCS5_PBKDF2_HMAC_SHA1((const char*)password, cb_password, salt, cb_salt, iterations, cb_key, key);
+  PKCS5_PBKDF2_HMAC_SHA1((const char*)password, cb_password, salt, cb_salt, iterations, cb_key, (unsigned char*)key);
+#pragma GCC diagnostic pop
 
 #endif
 
@@ -491,7 +505,6 @@ setting_bool_t _get_bool_config(const char *sz_setting) {
 
 #ifdef _WIN32
   HKEY hKey = 0;
-  DWORD dwErr = 0;
   DWORD dwValue = 0;
   DWORD dwType = 0;
   DWORD cbValue = sizeof(dwValue);

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -178,21 +178,20 @@ union u_APDU {
 typedef union u_APDU APDU;
 typedef struct des_key des_key;
 
-extern unsigned const char aid[];
-
 des_rc des_import_key(const int type, const unsigned char* keyraw, const size_t keyrawlen, des_key** key);
 des_rc des_destroy_key(des_key* key);
 des_rc des_encrypt(des_key* key, const unsigned char* in, const size_t inlen, unsigned char* out, size_t* outlen);
 des_rc des_decrypt(des_key* key, const unsigned char* in, const size_t inlen, unsigned char* out, size_t* outlen);
-pkcs5_rc pkcs5_pbkdf2_sha1(const unsigned char* password, const size_t cb_password, const unsigned char* salt, const size_t cb_salt, unsigned long long iterations, unsigned char* key, const size_t cb_key);
+pkcs5_rc pkcs5_pbkdf2_sha1(const uint8_t* password, const size_t cb_password, const uint8_t* salt, const size_t cb_salt, uint64_t iterations, const uint8_t* key, const size_t cb_key);
 bool   yk_des_is_weak_key(const unsigned char *key, const size_t cb_key);
 
 prng_rc _ykpiv_prng_generate(unsigned char *buffer, const size_t cb_req);
 ykpiv_rc _ykpiv_begin_transaction(ykpiv_state *state);
 ykpiv_rc _ykpiv_end_transaction(ykpiv_state *state);
 ykpiv_rc _ykpiv_ensure_application_selected(ykpiv_state *state);
-int _ykpiv_set_length(unsigned char *buffer, size_t length);
-int _ykpiv_get_length(const unsigned char *buffer, size_t *len);
+ykpiv_rc _ykpiv_select_application(ykpiv_state *state);
+unsigned int _ykpiv_set_length(unsigned char *buffer, size_t length);
+unsigned int _ykpiv_get_length(const unsigned char *buffer, size_t *len);
 
 void* _ykpiv_alloc(ykpiv_state *state, size_t size);
 void* _ykpiv_realloc(ykpiv_state *state, void *address, size_t size);
@@ -200,8 +199,14 @@ void _ykpiv_free(ykpiv_state *state, void *data);
 ykpiv_rc _ykpiv_save_object(ykpiv_state *state, int object_id, unsigned char *indata, size_t len);
 ykpiv_rc _ykpiv_fetch_object(ykpiv_state *state, int object_id, unsigned char *data, unsigned long *len);
 ykpiv_rc _send_data(ykpiv_state *state, APDU *apdu, unsigned char *data, uint32_t *recv_len, int *sw);
-ykpiv_rc _ykpiv_get_version(ykpiv_state *state, ykpiv_version_t *p_version);
-ykpiv_rc _ykpiv_util_get_serial(ykpiv_state *state, uint32_t *p_serial, bool f_force);
+ykpiv_rc _ykpiv_transfer_data(
+    ykpiv_state *state,
+    const unsigned char *templ,
+    const unsigned char *in_data,
+    long in_len,
+    unsigned char *out_data,
+    unsigned long *out_len,
+    int *sw);
 
 /* authentication functions not ready for public api */
 ykpiv_rc ykpiv_auth_getchallenge(ykpiv_state *state, uint8_t *challenge, const size_t challenge_len);

--- a/lib/ykpiv.h
+++ b/lib/ykpiv.h
@@ -194,6 +194,19 @@ extern "C"
    */
   ykpiv_rc ykpiv_verify_select(ykpiv_state *state, const char *pin, const size_t pin_len, int *tries, bool force_select);
 
+  /**
+   * Get serial number
+   *
+   * The card must be connected to call this function.
+   *
+   * @param state [in] State handle
+   * @param p_serial [out] uint32 to store retrieved serial number
+   *
+   * @return ykpiv_rc error code
+   *
+   */
+  ykpiv_rc ykpiv_get_serial(ykpiv_state *state, uint32_t* p_serial);
+
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -492,7 +505,7 @@ extern "C"
    * @param state state
    * @param ccc Unique Card ID to set. If NULL, randomly generate.
    *
-   * @return ypiv_rc error code
+   * @return ykpiv_rc error code
    *
    */
   ykpiv_rc ykpiv_util_set_cccid(ykpiv_state *state, const ykpiv_cccid *ccc);
@@ -647,6 +660,7 @@ extern "C"
 #define YKPIV_INS_RESET 0xfb
 #define YKPIV_INS_SET_PIN_RETRIES 0xfa
 #define YKPIV_INS_ATTEST 0xf9
+#define YKPIV_INS_GET_SERIAL 0xf8
 
 #define YKPIV_PINPOLICY_TAG 0xaa
 #define YKPIV_PINPOLICY_DEFAULT 0
@@ -671,12 +685,15 @@ extern "C"
 
 #define YKPIV_ATR_NEO_R3 "\x3b\xfc\x13\x00\x00\x81\x31\xfe\x15\x59\x75\x62\x69\x6b\x65\x79\x4e\x45\x4f\x72\x33\xe1"
 #define YKPIV_ATR_YK4    "\x3b\xf8\x13\x00\x00\x81\x31\xfe\x15\x59\x75\x62\x69\x6b\x65\x79\x34\xd4"
+#define YKPIV_ATR_YK5_P1 "\x3b\xf8\x13\x00\x00\x81\x31\xfe\x15\x01\x59\x75\x62\x69\x4b\x65\x79\xc1"
+#define YKPIV_ATR_YK5    "\x3b\xfd\x13\x00\x00\x81\x31\xfe\x15\x80\x73\xc0\x21\xc0\x57\x59\x75\x62\x69\x4b\x65\x79\x40"
 
 #define DEVTYPE_UNKNOWN  0x00000000
 #define DEVTYPE_NEO      0x4E450000 //"NE"
 #define DEVTYPE_YK       0x594B0000 //"YK"
 #define DEVTYPE_NEOr3    (DEVTYPE_NEO | 0x00007233) //"r3"
 #define DEVTYPE_YK4      (DEVTYPE_YK  | 0x00000034) // "4"
+#define DEVYTPE_YK5      (DEVTYPE_YK  | 0x00000035) // "5"
 
 #ifdef __cplusplus
 }

--- a/lib/ykpiv.map
+++ b/lib/ykpiv.map
@@ -113,3 +113,9 @@ global:
     ykpiv_util_write_msroots;
     ykpiv_verify_select;
 } YKPIV_1.3.0;
+
+YKPIV_1.6.0
+{
+global:
+    ykpiv_get_serial;
+} YKPIV_1.5.0;


### PR DESCRIPTION
lib: promote get_serial to base API
lib: add ykpiv_get_serial to external API
tool: add serial number/version to status command
build: fix msvc build of case insensitive-reader (missing strncasecmp and cast warnings)
lib: consolidate neo/yk4 + yk5 serial number routines
lib: fix GCC 8 compilier warnings
lib: reimplement deauthenticate to select mgmt aid
build: disable -Waggregate-return
lib: fix warning differences between gcc and msvc
lib: add option to disable implicit card transactions
lib: remove application reselect prior to crypt operations
build: fix msvc warnings wrt length checking logic fixes
lib: fix error condition logic in untransacted internal functions
lib: create internal transactionless ykpiv_transfer_data