### PR TITLE
Increase get_objects buffer; Fix typo in error message

### DIFF
--- a/lib/ykpiv.c
+++ b/lib/ykpiv.c
@@ -584,7 +584,7 @@ ykpiv_rc _ykpiv_transfer_data(ykpiv_state *state, const unsigned char *templ,
     }
     if(*out_len + recv_len - 2 > max_out) {
       if(state->verbose) {
-        fprintf(stderr, "Output buffer to small, wanted to write %lu, max was %lu.\n", *out_len + recv_len - 2, max_out);
+        fprintf(stderr, "Output buffer too small, wanted to write %lu, max was %lu.\n", *out_len + recv_len - 2, max_out);
       }
       res = YKPIV_SIZE_ERROR;
       goto Cleanup;
@@ -615,7 +615,7 @@ ykpiv_rc _ykpiv_transfer_data(ykpiv_state *state, const unsigned char *templ,
     }
     if(*out_len + recv_len - 2 > max_out) {
       if(state->verbose) {
-        fprintf(stderr, "Output buffer to small, wanted to write %lu, max was %lu.", *out_len + recv_len - 2, max_out);
+        fprintf(stderr, "Output buffer too small, wanted to write %lu, max was %lu.", *out_len + recv_len - 2, max_out);
       }
       res = YKPIV_SIZE_ERROR;
       goto Cleanup;

--- a/ykcs11/yubico_token.c
+++ b/ykcs11/yubico_token.c
@@ -242,7 +242,7 @@ CK_RV YUBICO_get_token_mechanism_info(CK_MECHANISM_TYPE mec, CK_MECHANISM_INFO_P
 
 static CK_RV get_objects(ykpiv_state *state, CK_BBOOL num_only,
                          piv_obj_id_t *obj, CK_ULONG_PTR len, CK_ULONG_PTR num_certs) {
-  CK_BYTE      buf[2048];
+  CK_BYTE      buf[2100];
   CK_ULONG     buf_len;
   CK_BYTE      major;
   CK_ULONG     i;


### PR DESCRIPTION
Trying to read from a YubiKey 4 I got the following:
```
# p11tool --export 'pkcs11:model=YubiKey%20YK4;manufacturer=Yubico;serial=1234;token=YubiKey%20PIV;object=X.509%20Certificate%20for%20PIV%20Authentication%00' --debug 100
Setting log level to 100
debug: ykcs11.c:172 (C_GetFunctionList): In
debug: ykcs11.c:180 (C_GetFunctionList): Out
debug: ykcs11.c:87 (C_Initialize): In
trying to connect to reader 'Yubico YubiKey OTP+FIDO+CCID 00 00'.
debug: ykcs11.c:105 (C_Initialize): Found 1 slot(s) of which 0 tokenless/unsupported
debug: ykcs11.c:110 (C_Initialize): Out
|<2>| p11: Initializing module: p11-kit-trust
|<2>| p11: Initializing module: ykcs11
debug: ykcs11.c:150 (C_GetInfo): In
debug: ykcs11.c:164 (C_GetInfo): Out
|<3>| ASSERT: pkcs11.c[compat_load]:891
debug: ykcs11.c:195 (C_GetSlotList): In
debug: ykcs11.c:237 (C_GetSlotList): token present is 1
debug: ykcs11.c:238 (C_GetSlotList): number of slot(s) is 1
debug: ykcs11.c:240 (C_GetSlotList): Out
debug: ykcs11.c:272 (C_GetTokenInfo): In
debug: ykcs11.c:313 (C_GetTokenInfo): Out
debug: ykcs11.c:249 (C_GetSlotInfo): In
debug: ykcs11.c:263 (C_GetSlotInfo): Out
debug: ykcs11.c:512 (C_OpenSession): In
trying to connect to reader 'Yubico YubiKey OTP+FIDO+CCID 00 00'.
debug: yubico_token.c:273 (get_objects): Found AUTH cert (9a)
debug: yubico_token.c:300 (get_objects): Found KMK cert (9d)
Output buffer to small, wanted to write 2070, max was 2048.debug: yubico_token.c:317 (get_objects): The total number of objects for this token is 35
debug: yubico_token.c:273 (get_objects): Found AUTH cert (9a)
debug: yubico_token.c:300 (get_objects): Found KMK cert (9d)
Output buffer to small, wanted to write 2070, max was 2048.debug: yubico_token.c:317 (get_objects): The total number of objects for this token is 35
```
No idea what the proper buffer size is here.