### PR TITLE
Serial number + Windows build fixes

### DIFF
--- a/lib/internal.c
+++ b/lib/internal.c
@@ -1,6 +1,5 @@
 #ifdef _WIN32
 #include <windows.h>
-#include <strsafe.h>
 #ifdef _MSC_VER
 #define strcasecmp _stricmp
 #endif
@@ -23,6 +22,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <strsafe.h> /* must be included after openssl headers */
+#endif
 
 #include "internal.h"
 

--- a/lib/ykpiv.c
+++ b/lib/ykpiv.c
@@ -305,7 +305,19 @@ ykpiv_rc _ykpiv_select_application(ykpiv_state *state) {
    * will result in another selection of the PIV applet. */
 
   res = _ykpiv_get_version(state, NULL);
-  if (res == YKPIV_OK) res = _ykpiv_get_serial(state, NULL, false);
+  if (res != YKPIV_OK) {
+    if (state->verbose) {
+      fprintf(stderr, "Failed to retrieve version: '%s'\n", ykpiv_strerror(res));
+    }
+  }
+
+  res = _ykpiv_get_serial(state, NULL, false);
+  if (res != YKPIV_OK) {
+    if (state->verbose) {
+      fprintf(stderr, "Failed to retrieve serial number: '%s'\n", ykpiv_strerror(res));
+    }
+    res = YKPIV_OK;
+  }
 
   return res;
 }

--- a/ykcs11/ykcs11.c
+++ b/ykcs11/ykcs11.c
@@ -1842,6 +1842,7 @@ CK_DEFINE_FUNCTION(CK_RV, C_Sign)(
 {
   ykpiv_rc piv_rv;
   CK_RV    rv;
+  size_t   cbSignatureLen = 0;
 
   DIN;
 
@@ -1934,9 +1935,12 @@ CK_DEFINE_FUNCTION(CK_RV, C_Sign)(
   dump_data(op_info.buf, op_info.buf_len, stderr, CK_TRUE, format_arg_hex);
 #endif
 
-  *pulSignatureLen = sizeof(op_info.buf);
+  *pulSignatureLen = cbSignatureLen = sizeof(op_info.buf);
 
-  piv_rv = ykpiv_sign_data(piv_state, op_info.buf, op_info.buf_len, op_info.buf, pulSignatureLen, op_info.op.sign.algo, op_info.op.sign.key_id);
+  piv_rv = ykpiv_sign_data(piv_state, op_info.buf, op_info.buf_len, op_info.buf, &cbSignatureLen, op_info.op.sign.algo, op_info.op.sign.key_id);
+
+  *pulSignatureLen = cbSignatureLen;
+
   if (piv_rv != YKPIV_OK) {
     if (piv_rv == YKPIV_AUTHENTICATION_ERROR) {
       DBG("Operation requires authentication or touch");


### PR DESCRIPTION
lib: warn, but don't fail on error reading serial number or version
lib: fix Windows build with OpenSSL 1.1.1
ykcs11: fix size_t/unsigned long type mismatch on Windows x64