### PR TITLE
Ignore CKA_LABEL on calls to check_{pub/pvt}key_template

### DIFF
--- a/ykcs11/mechanisms.c
+++ b/ykcs11/mechanisms.c
@@ -439,6 +439,7 @@ CK_RV check_pubkey_template(op_info_t *op_info, CK_ATTRIBUTE_PTR templ, CK_ULONG
     case CKA_WRAP:
     case CKA_DERIVE:
     case CKA_PRIVATE:
+    case CKA_LABEL:
       // Ignore these attributes for now
       break;
 
@@ -508,6 +509,7 @@ CK_RV check_pvtkey_template(op_info_t *op_info, CK_ATTRIBUTE_PTR templ, CK_ULONG
     case CKA_PRIVATE:
     case CKA_TOKEN:
     case CKA_DERIVE:
+    case CKA_LABEL:
       // Ignore these attributes for now
       break;
 


### PR DESCRIPTION
Adding a `CKA_LABEL` attribute when calling `C_GenerateKeyPair` will cause a `CKR_ATTRIBUTE_TYPE_INVALID` error as it is falls through to the default case.

It appears that the label value defaults to e.g. `Public key for PIV Authentication` so I assumed this error is not necessary.