### PR TITLE
error message when yubikey must be reinserted.

### DIFF
--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -1983,7 +1983,7 @@ int main(int argc, char *argv[]) {
   }
 
   if(ykpiv_connect(state, args_info.reader_arg) != YKPIV_OK) {
-    fprintf(stderr, "Failed to connect to reader.\n");
+    fprintf(stderr, "Failed to connect to yubikey.\nHave you tried turning it off and on again?");
     return EXIT_FAILURE;
   }
 

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -1983,7 +1983,7 @@ int main(int argc, char *argv[]) {
   }
 
   if(ykpiv_connect(state, args_info.reader_arg) != YKPIV_OK) {
-    fprintf(stderr, "Failed to connect to yubikey.\nHave you tried turning it off and on again?");
+    fprintf(stderr, "Failed to connect to yubikey.\nTry removing and reconnecting the device.");
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
instead of repeating almost word-for-word the diagnostic error from ykcs11 lib (which is show right above this line btw), show something that have *any* meaning to the end user, who likely do not know what a "reader" is.

Before:
```
$ yubico-piv-tool --verbose -a status
error: no usable reader found.
Failed to connect to reader.
```

after
```
$ yubico-piv-tool --verbose -a status
error: no usable reader found.
Failed to connect to yubikey.
Have you tried turning it off and on again
```

The last line is, obviously, helpful but extraneous, mostly to make a point that i am not a contributor here and someone who knows the end users better than i do should write the actual new text.