### PR TITLE
Clarifying mgmt key error

### DIFF
--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -2120,7 +2120,7 @@ int main(int argc, char *argv[]) {
             fprintf(stderr, "Successfully set new management key.\n");
           }
         } else {
-          fprintf(stderr, "The new management key has to be exactly %d character.\n", KEY_LEN * 2);
+          fprintf(stderr, "The new management key has to be exactly %d hexidecimal characters.\n", KEY_LEN * 2);
           ret = EXIT_FAILURE;
         }
         break;


### PR DESCRIPTION
Key needs to be 48 but also only hexidecimal is supported. This is not very clear in the error nor in documentation at https://developers.yubico.com/yubikey-piv-manager/PIN_and_Management_Key.html