### PR TITLE
yubico-piv-tool: avoid obsolete macro M_ASN1_BIT_STRING_set

### DIFF
--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -751,7 +751,7 @@ static bool request_certificate(ykpiv_state *state, enum enum_key_format key_for
       fprintf(stderr, "Failed signing request.\n");
       goto request_out;
     }
-    M_ASN1_BIT_STRING_set(req->signature, signature, sig_len);
+    ASN1_STRING_set(req->signature, signature, sig_len);
     /* mark that all bits should be used. */
     req->signature->flags = ASN1_STRING_FLAG_BITS_LEFT;
   }
@@ -1007,7 +1007,7 @@ static bool selfsign_certificate(ykpiv_state *state, enum enum_key_format key_fo
       fprintf(stderr, "Failed signing certificate.\n");
       goto selfsign_out;
     }
-    M_ASN1_BIT_STRING_set(x509->signature, signature, sig_len);
+    ASN1_STRING_set(x509->signature, signature, sig_len);
     /* setting flags to ASN1_STRING_FLAG_BITS_LEFT here marks that no bits
      * should be subtracted from the bit string, thus making sure that the
      * certificate can be validated. */


### PR DESCRIPTION
From commit f422a51486, ("Remove old ASN.1 code.", 2015-03-14),
OpenSSL no longer provides M_ASN1_* macro.

In that change, OpenSSL replaced M_ASN1_BIT_STRING_set with
ASN1_STRING_set.

Follow OpenSSL steps to support all rolling-release distro.

Signed-off-by: Doan Tran Cong Danh <congdanhqx@gmail.com>

---
https://github.com/openssl/openssl/commit/f422a51486