### PR TITLE
Use relative path to include ykpiv-version.h

### DIFF
--- a/lib/ykpiv.h
+++ b/lib/ykpiv.h
@@ -43,7 +43,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-#include <ykpiv-version.h>
+#include "ykpiv-version.h"
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
This PR makes sure the `ykpiv-version.h` header is included with a relative path.

This allows users to include the `ykpiv.h` header through `#include <ykpiv/ykpiv.h>` without adding `/usr/include/ykpiv` to the include path.