### PR TITLE
Libressl 3.0.2 partial fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -280,6 +280,10 @@ AS_IF([test "x$enable_hardware_tests" != xno],
 AY_OPENSSL_CHECK_FUNC(RSA_set0_key,[[#include <openssl/rsa.h>]])
 AY_OPENSSL_CHECK_FUNC(RSA_get0_factors,[[#include <openssl/rsa.h>]])
 AY_OPENSSL_CHECK_FUNC(RSA_get0_crt_params,[[#include <openssl/rsa.h>]])
+AY_OPENSSL_CHECK_FUNC(RSA_padding_add_PKCS1_OAEP_mgf1,
+		      [[#include <openssl/rsa.h>]])
+AY_OPENSSL_CHECK_FUNC(RSA_padding_check_PKCS1_OAEP_mgf1,
+		      [[#include <openssl/rsa.h>]])
 AY_OPENSSL_CHECK_FUNC(X509_SIG_getm,[[#include <openssl/x509.h>]])
 AY_OPENSSL_CHECK_FUNC(ECDSA_SIG_set0,[[#include <openssl/ecdsa.h>]])
 AY_OPENSSL_CHECK_FUNC(EVP_PKEY_get0_RSA,[[

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,21 @@ AM_MISSING_PROG(HELP2ADOC, help2adoc, $missing_dir)
 AM_MISSING_PROG(GENGETOPT, gengetopt, $missing_dir)
 PKG_PROG_PKG_CONFIG
 
+AC_DEFUN([AY_OPENSSL_CHECK_FUNC],
+AC_CACHE_CHECK([for prototype $1],
+[ay_cv_openssl_have_$1],
+[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([$2],[[
+ #ifndef $1
+ void *fp = $1;
+ #endif
+]])],
+[ay_cv_openssl_have_$1=yes],
+[ay_cv_openssl_have_$1=no])])
+if test "x$ay_cv_openssl_have_$1" = xyes; then
+	AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_DECL_]$1))
+fi
+)
+
 PKG_CHECK_MODULES([OPENSSL], [libcrypto], [OPENSSL_VERSION=`$PKG_CONFIG --modversion libcrypto`])
 PKG_CHECK_MODULES([CHECK], [check >= 0.9.6])
 
@@ -261,6 +276,21 @@ AS_IF([test "x$enable_hardware_tests" != xno],
              hw_tests="ENABLED"],
       [true],
             [hw_tests="DISABLED"])
+
+AY_OPENSSL_CHECK_FUNC(RSA_set0_key,[[#include <openssl/rsa.h>]])
+AY_OPENSSL_CHECK_FUNC(RSA_get0_factors,[[#include <openssl/rsa.h>]])
+AY_OPENSSL_CHECK_FUNC(RSA_get0_crt_params,[[#include <openssl/rsa.h>]])
+AY_OPENSSL_CHECK_FUNC(X509_SIG_getm,[[#include <openssl/x509.h>]])
+AY_OPENSSL_CHECK_FUNC(ECDSA_SIG_set0,[[#include <openssl/ecdsa.h>]])
+AY_OPENSSL_CHECK_FUNC(EVP_PKEY_get0_RSA,[[
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+]])
+AY_OPENSSL_CHECK_FUNC(EVP_PKEY_get0_EC_KEY,[[
+#include <openssl/ecdsa.h>
+#include <openssl/evp.h>
+#include <openssl/dh.h>
+]])
 
 AC_SUBST(YKPIV_VERSION_MAJOR, `echo $PACKAGE_VERSION | sed 's/\(.*\)\..*\..*/\1/g'`)
 AC_SUBST(YKPIV_VERSION_MINOR, `echo $PACKAGE_VERSION | sed 's/.*\.\(.*\)\..*/\1/g'`)

--- a/tool/openssl-compat.c
+++ b/tool/openssl-compat.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <openssl/engine.h>
 
+#ifndef HAVE_DECL_RSA_SET0_KEY
 int yubico_RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
 {
     /* If the fields n and e in r are NULL, the corresponding input
@@ -48,7 +49,9 @@ void yubico_RSA_get0_key(const RSA *r,
     if (d != NULL)
         *d = r->d;
 }
+#endif /* HAVE_DECL_RSA_SET0_KEY */
 
+#ifndef HAVE_DECL_RSA_GET0_FACTORS
 void yubico_RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q)
 {
     if (p != NULL)
@@ -56,7 +59,9 @@ void yubico_RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q)
     if (q != NULL)
         *q = r->q;
 }
+#endif /* HAVE_DECL_RSA_GET0_FACTORS */
 
+#ifndef HAVE_DECL_RSA_GET0_CRT_PARAMS
 void yubico_RSA_get0_crt_params(const RSA *r,
                          const BIGNUM **dmp1, const BIGNUM **dmq1,
                          const BIGNUM **iqmp)
@@ -68,7 +73,9 @@ void yubico_RSA_get0_crt_params(const RSA *r,
     if (iqmp != NULL)
         *iqmp = r->iqmp;
 }
+#endif /* HAVE_DECL_RSA_GET0_CRT_PARAMS */
 
+#ifndef HAVE_DECL_X509_SIG_GETM
 void yubico_X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
                    ASN1_OCTET_STRING **pdigest)
 {
@@ -77,7 +84,9 @@ void yubico_X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
     if (pdigest)
         *pdigest = sig->digest;
 }
+#endif /* HAVE_DECL_X509_SIG_GETM */
 
+#ifndef HAVE_DECL_ECDSA_SIG_SET0
 int yubico_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
 {
     if (r == NULL || s == NULL)
@@ -95,19 +104,24 @@ void yubico_ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM
     if (ps != NULL)
         *ps = sig->s;
 }
+#endif /* HAVE_DECL_ECDSA_SIG_SET0 */
 
+#ifndef HAVE_DECL_EVP_PKEY_GET0_RSA
 RSA *yubico_EVP_PKEY_get0_RSA(const EVP_PKEY *pkey) {
   if (pkey->type != EVP_PKEY_RSA) {
     return NULL;
   }
   return pkey->pkey.rsa;
 }
+#endif /* HAVE_DECL_EVP_PKEY_GET0_RSA */
 
+#ifndef HAVE_DECL_EVP_PKEY_GET0_EC_KEY
 EC_KEY *yubico_EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey) {
   if (pkey->type != EVP_PKEY_EC) {
     return NULL;
   }
   return pkey->pkey.ec;
 }
+#endif /* HAVE_DECL_EVP_PKEY_GET0_EC_KEY */
 
 #endif /* OPENSSL_VERSION_NUMBER || LIBRESSL_VERSION_NUMBER */

--- a/tool/openssl-compat.c
+++ b/tool/openssl-compat.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <openssl/engine.h>
 
-int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
+int yubico_RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
 {
     /* If the fields n and e in r are NULL, the corresponding input
      * parameters MUST be non-NULL for n and e.  d may be
@@ -38,7 +38,7 @@ int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
     return 1;
 }
 
-void RSA_get0_key(const RSA *r,
+void yubico_RSA_get0_key(const RSA *r,
                   const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
 {
     if (n != NULL)
@@ -49,7 +49,7 @@ void RSA_get0_key(const RSA *r,
         *d = r->d;
 }
 
-void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q)
+void yubico_RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q)
 {
     if (p != NULL)
         *p = r->p;
@@ -57,7 +57,7 @@ void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q)
         *q = r->q;
 }
 
-void RSA_get0_crt_params(const RSA *r,
+void yubico_RSA_get0_crt_params(const RSA *r,
                          const BIGNUM **dmp1, const BIGNUM **dmq1,
                          const BIGNUM **iqmp)
 {
@@ -69,7 +69,7 @@ void RSA_get0_crt_params(const RSA *r,
         *iqmp = r->iqmp;
 }
 
-void X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
+void yubico_X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
                    ASN1_OCTET_STRING **pdigest)
 {
     if (palg)
@@ -78,7 +78,7 @@ void X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
         *pdigest = sig->digest;
 }
 
-int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
+int yubico_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
 {
     if (r == NULL || s == NULL)
         return 0;
@@ -89,21 +89,21 @@ int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
     return 1;
 }
 
-void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps) {
+void yubico_ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps) {
     if (pr != NULL)
         *pr = sig->r;
     if (ps != NULL)
         *ps = sig->s;
 }
 
-RSA *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey) {
+RSA *yubico_EVP_PKEY_get0_RSA(const EVP_PKEY *pkey) {
   if (pkey->type != EVP_PKEY_RSA) {
     return NULL;
   }
   return pkey->pkey.rsa;
 }
 
-EC_KEY *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey) {
+EC_KEY *yubico_EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey) {
   if (pkey->type != EVP_PKEY_EC) {
     return NULL;
   }

--- a/tool/openssl-compat.h
+++ b/tool/openssl-compat.h
@@ -65,6 +65,19 @@ EC_KEY *yubico_EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey);
 #define EVP_PKEY_get0_EC_KEY yubico_EVP_PKEY_get0_EC_KEY
 #endif /* HAVE_DECL_EVP_PKEY_GET0_EC_KEY */
 
+#ifndef EVP_PKEY_CTRL_RSA_OAEP_MD
+#define EVP_PKEY_CTRL_RSA_OAEP_MD		(EVP_PKEY_ALG_CTRL + 9)
+#define EVP_PKEY_CTRL_RSA_OAEP_LABEL		(EVP_PKEY_ALG_CTRL + 10)
+#define EVP_PKEY_CTX_set_rsa_oaep_md(ctx, md) \
+	EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, EVP_PKEY_OP_TYPE_CRYPT, \
+	    EVP_PKEY_CTRL_RSA_OAEP_MD, 0, (void *)(md))
+
+#define EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, l, llen) \
+	EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, EVP_PKEY_OP_TYPE_CRYPT, \
+	    EVP_PKEY_CTRL_RSA_OAEP_LABEL, llen, (void *)(l))
+
+#endif /* EVP_PKEY_CTRL_RSA_OAEP_MD */
+
 #endif /* _WINDOWS */
 #endif /* OPENSSL_VERSION_NUMBER || LIBRESSL_VERSION_NUMBER */
 #endif /* LIBCRYPTO_COMPAT_H */

--- a/tool/openssl-compat.h
+++ b/tool/openssl-compat.h
@@ -22,19 +22,34 @@
 #include <openssl/evp.h>
 #include <openssl/x509.h>
 
-int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
-void RSA_get0_key(const RSA *r,
+int yubico_RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
+#define RSA_set0_key yubico_RSA_set0_key
+void yubico_RSA_get0_key(const RSA *r,
                   const BIGNUM **n, const BIGNUM **e, const BIGNUM **d);
-void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q);
-void RSA_get0_crt_params(const RSA *r,
+#define RSA_get0_key yubico_RSA_get0_key
+
+void yubico_RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q);
+#define RSA_get0_factors yubico_RSA_get0_factors
+
+void yubico_RSA_get0_crt_params(const RSA *r,
                          const BIGNUM **dmp1, const BIGNUM **dmq1,
                          const BIGNUM **iqmp);
-void X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
+#define RSA_get0_crt_params yubico_RSA_get0_crt_params
+
+void yubico_X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
                    ASN1_OCTET_STRING **pdigest);
-int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
-void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
-RSA *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey);
-EC_KEY *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey);
+#define X509_SIG_getm yubico_X509_SIG_getm
+
+int yubico_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
+#define ECDSA_SIG_set0 yubico_ECDSA_SIG_set0
+void yubico_ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
+#define ECDSA_SIG_get0 yubico_ECDSA_SIG_get0
+
+RSA *yubico_EVP_PKEY_get0_RSA(const EVP_PKEY *pkey);
+#define EVP_PKEY_get0_RSA yubico_EVP_PKEY_get0_RSA
+
+EC_KEY *yubico_EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey);
+#define EVP_PKEY_get0_EC_KEY yubico_EVP_PKEY_get0_EC_KEY
 
 #endif /* _WINDOWS */
 #endif /* OPENSSL_VERSION_NUMBER || LIBRESSL_VERSION_NUMBER */

--- a/tool/openssl-compat.h
+++ b/tool/openssl-compat.h
@@ -22,34 +22,48 @@
 #include <openssl/evp.h>
 #include <openssl/x509.h>
 
+#ifndef HAVE_DECL_RSA_SET0_KEY
 int yubico_RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
 #define RSA_set0_key yubico_RSA_set0_key
 void yubico_RSA_get0_key(const RSA *r,
                   const BIGNUM **n, const BIGNUM **e, const BIGNUM **d);
 #define RSA_get0_key yubico_RSA_get0_key
+#endif /* HAVE_DECL_RSA_SET0_KEY */
 
+#ifndef HAVE_DECL_RSA_GET0_FACTORS
 void yubico_RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q);
 #define RSA_get0_factors yubico_RSA_get0_factors
+#endif /* HAVE_DECL_RSA_GET0_FACTORS */
 
+#ifndef HAVE_DECL_RSA_GET0_CRT_PARAMS
 void yubico_RSA_get0_crt_params(const RSA *r,
                          const BIGNUM **dmp1, const BIGNUM **dmq1,
                          const BIGNUM **iqmp);
 #define RSA_get0_crt_params yubico_RSA_get0_crt_params
+#endif /* HAVE_DECL_RSA_GET0_CRT_PARAMS */
 
+#ifndef HAVE_DECL_X509_SIG_GETM
 void yubico_X509_SIG_getm(X509_SIG *sig, X509_ALGOR **palg,
                    ASN1_OCTET_STRING **pdigest);
 #define X509_SIG_getm yubico_X509_SIG_getm
+#endif /* HAVE_DECL_X509_SIG_GETM */
 
+#ifndef HAVE_DECL_ECDSA_SIG_SET0
 int yubico_ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 #define ECDSA_SIG_set0 yubico_ECDSA_SIG_set0
 void yubico_ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
 #define ECDSA_SIG_get0 yubico_ECDSA_SIG_get0
+#endif /* HAVE_DECL_ECDSA_SIG_SET0 */
 
+#ifndef HAVE_DECL_EVP_PKEY_GET0_RSA
 RSA *yubico_EVP_PKEY_get0_RSA(const EVP_PKEY *pkey);
 #define EVP_PKEY_get0_RSA yubico_EVP_PKEY_get0_RSA
+#endif /* HAVE_DECL_EVP_PKEY_GET0_RSA */
 
+#ifndef HAVE_DECL_EVP_PKEY_GET0_EC_KEY
 EC_KEY *yubico_EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey);
 #define EVP_PKEY_get0_EC_KEY yubico_EVP_PKEY_get0_EC_KEY
+#endif /* HAVE_DECL_EVP_PKEY_GET0_EC_KEY */
 
 #endif /* _WINDOWS */
 #endif /* OPENSSL_VERSION_NUMBER || LIBRESSL_VERSION_NUMBER */

--- a/tool/openssl-compat.h
+++ b/tool/openssl-compat.h
@@ -78,6 +78,20 @@ EC_KEY *yubico_EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey);
 
 #endif /* EVP_PKEY_CTRL_RSA_OAEP_MD */
 
+#ifndef HAVE_DECL_RSA_PADDING_CHECK_PKCS1_OAEP_MGF1
+int yubico_RSA_padding_check_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
+    const unsigned char *from, int flen, int num, const unsigned char *param,
+    int plen, const EVP_MD *md, const EVP_MD *mgf1md);
+#define RSA_padding_check_PKCS1_OAEP_mgf1 yubico_RSA_padding_check_PKCS1_OAEP_mgf1
+#endif /* HAVE_DECL_RSA_PADDING_CHECK_PKCS1_OAEP_MGF1 */
+
+#ifndef HAVE_DECL_RSA_PADDING_ADD_PKCS1_OAEP_MGF1
+int yubico_RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
+    const unsigned char *from, int flen, const unsigned char *param, int plen,
+    const EVP_MD *md, const EVP_MD *mgf1md);
+#define RSA_padding_add_PKCS1_OAEP_mgf1 yubico_RSA_padding_add_PKCS1_OAEP_mgf1
+#endif /* HAVE_DECL_RSA_PADDING_ADD_PKCS1_OAEP_MGF1 */
+
 #endif /* _WINDOWS */
 #endif /* OPENSSL_VERSION_NUMBER || LIBRESSL_VERSION_NUMBER */
 #endif /* LIBCRYPTO_COMPAT_H */

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -28,6 +28,7 @@
  *
  */
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>


### PR DESCRIPTION
Hi, the latest release failed to be built with libressl (at least with version 3.0.2).

Here is a partial fix.

~leftoverbit:~
- `RSA_padding_check_PKCS1_OAEP_mgf1` is undefined in libressl as of now, it's available upstream, but not make it into release, yet.--> Copy-Paste code from libressl
- RSA_padding_add_PKCS1_OAEP_mgf1 --> Copy-Paste code from libressl