### PR TITLE
ykcs11: allow setting reader prefix for NFC use

### DIFF
--- a/ykcs11/utils.c
+++ b/ykcs11/utils.c
@@ -47,7 +47,12 @@
 #include <string.h>
 
 CK_BBOOL is_yubico_reader(const char* reader_name) {
-  return !strncmp(reader_name, "Yubico", 6);
+  static const char *prefix = NULL;
+  if (prefix == NULL)
+    prefix = getenv("YKCS11_READER_PREFIX");
+  if (prefix == NULL)
+    prefix = "Yubico";
+  return !strncmp(reader_name, prefix, strlen(prefix));
 }
 
 size_t memstrcpy(unsigned char *dst, size_t size, const char *src) {


### PR DESCRIPTION
It would be nice to be able to use libykcs11 against YubiKeys on an NFC reader. This patch allows setting the environment variable `YKCS11_READER_PREFIX` to a value other than `"Yubico"` so that libykcs11 can find NFC readers as needed.