### PR TITLE
Fix FTBFS when building with BUILD_STATIC_LIB=OFF

### DIFF
--- a/ykcs11/CMakeLists.txt
+++ b/ykcs11/CMakeLists.txt
@@ -83,7 +83,6 @@ add_coverage(ykcs11_shared)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ykcs11.pc.in ${CMAKE_CURRENT_SOURCE_DIR}/ykcs11.pc @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ykcs11-config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/ykcs11-config.h @ONLY)
 
-set_target_properties(ykcs11 PROPERTIES INSTALL_RPATH "${YKPIV_INSTALL_LIB_DIR}")
 install(
         TARGETS ykcs11_shared
         ARCHIVE DESTINATION "${YKPIV_INSTALL_LIB_DIR}"
@@ -91,6 +90,7 @@ install(
         RUNTIME DESTINATION "${YKPIV_INSTALL_BIN_DIR}")
 
 if(BUILD_STATIC_LIB)
+    set_target_properties(ykcs11 PROPERTIES INSTALL_RPATH ${YKPIV_INSTALL_LIB_DIR})
     install(
         TARGETS ykcs11
         ARCHIVE DESTINATION "${YKPIV_INSTALL_LIB_DIR}"


### PR DESCRIPTION
Reproduction:

    cmake \
        -DBUILD_STATIC_LIB=OFF \
        -DBUILD_SHARED_LIBS=ON \
        -DCMAKE_GENERATOR='Unix Makefiles' \
        -DCMAKE_BUILD_TYPE='Release'

(running make isn't necessary, it fails during configure)

Fails with:

    CMake Error at ykcs11/CMakeLists.txt:86 (set_target_properties):
      set_target_properties Can not find target to add properties to: ykcs11