### PR TITLE
Use standard variables for install paths

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -25,6 +25,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+include(GNUInstallDirs)
+
 #These are the Variables that can be overridden with the command line arguments in the form:
 # cmake -DVARIABLE1=VALUE1 -DVARIABLE2=VALUE2
 
@@ -48,22 +50,8 @@ set(OPENSSL_PKG_PATH "" CACHE STRING "Path to be prepended to 'PKG_CONFIG_PATH' 
 set(PCSCLITE_PKG_PATH "" CACHE STRING "Path to be prepended to 'PKG_CONFIG_PATH' environment variable to look for pcsc-lite library")
 
 # Set various install paths
-if (NOT DEFINED YKPIV_INSTALL_LIB_DIR)
-    set(YKPIV_INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE PATH "Installation directory for libraries")
-endif ()
-
-if (NOT DEFINED YKPIV_INSTALL_INC_DIR)
-    set(YKPIV_INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "Installation directory for headers")
-endif ()
-
-if (NOT DEFINED YKPIV_INSTALL_BIN_DIR)
-    set(YKPIV_INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")
-endif ()
-
-if (NOT DEFINED YKPIV_INSTALL_MAN_DIR)
-    set(YKPIV_INSTALL_MAN_DIR "${CMAKE_INSTALL_PREFIX}/share/man" CACHE PATH "Installation directory for manual pages")
-endif ()
-
-if (NOT DEFINED YKPIV_INSTALL_PKGCONFIG_DIR)
-    set(YKPIV_INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
-endif ()
+set(YKPIV_INSTALL_LIB_DIR ${CMAKE_INSTALL_LIBDIR} CACHE PATH "Installation directory for libraries")
+set(YKPIV_INSTALL_INC_DIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE PATH "Installation directory for headers")
+set(YKPIV_INSTALL_BIN_DIR ${CMAKE_INSTALL_BINDIR} CACHE PATH "Installation directory for executables")
+set(YKPIV_INSTALL_MAN_DIR ${CMAKE_INSTALL_MANDIR} CACHE PATH "Installation directory for manual pages")
+set(YKPIV_INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")

--- a/lib/ykpiv.pc.in
+++ b/lib/ykpiv.pc.in
@@ -27,8 +27,8 @@
 
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@YKPIV_INSTALL_LIB_DIR@
-includedir=@YKPIV_INSTALL_INC_DIR@
+libdir=${prefix}/@YKPIV_INSTALL_LIB_DIR@
+includedir=${prefix}/@YKPIV_INSTALL_INC_DIR@
 
 Name: @CMAKE_PROJECT_NAME@
 Description: Yubico PIV C Library

--- a/ykcs11/ykcs11.pc.in
+++ b/ykcs11/ykcs11.pc.in
@@ -27,8 +27,8 @@
 
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@YKPIV_INSTALL_LIB_DIR@
-includedir=@YKPIV_INSTALL_INC_DIR@
+libdir=${prefix}/@YKPIV_INSTALL_LIB_DIR@
+includedir=${prefix}/@YKPIV_INSTALL_INC_DIR@
 
 Name: @CMAKE_PROJECT_NAME@
 Description: Yubico PIV PKCS#11 Module


### PR DESCRIPTION
`GNUInstallDirs` defines some standard `CACHE`-ed options:

    CMAKE_INSTALL_BINDIR           - user executables (bin)
    CMAKE_INSTALL_SBINDIR          - system admin executables (sbin)
    CMAKE_INSTALL_LIBEXECDIR       - program executables (libexec)
    CMAKE_INSTALL_SYSCONFDIR       - read-only single-machine data (etc)
    CMAKE_INSTALL_SHAREDSTATEDIR   - modifiable architecture-independent data (com)
    CMAKE_INSTALL_LOCALSTATEDIR    - modifiable single-machine data (var)
    CMAKE_INSTALL_LIBDIR           - object code libraries (lib or lib64 or lib/<multiarch-tuple> on Debian)
    CMAKE_INSTALL_INCLUDEDIR       - C header files (include)
    CMAKE_INSTALL_OLDINCLUDEDIR    - C header files for non-gcc (/usr/include)
    CMAKE_INSTALL_DATAROOTDIR      - read-only architecture-independent data root (share)
    CMAKE_INSTALL_DATADIR          - read-only architecture-independent data (DATAROOTDIR)
    CMAKE_INSTALL_INFODIR          - info documentation (DATAROOTDIR/info)
    CMAKE_INSTALL_LOCALEDIR        - locale-dependent data (DATAROOTDIR/locale)
    CMAKE_INSTALL_MANDIR           - man documentation (DATAROOTDIR/man)
    CMAKE_INSTALL_DOCDIR           - documentation root (DATAROOTDIR/doc/PROJECT_NAME)

[More info on GNUInstallDirs can be found here.](https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html)

Also the reason I got rid of the `NOT DEFINED` check is that the presence of the `CACHE` directive means it's setting a default that can be overridden using command line options, so there's no need to check if they're defined (they never are until `set(...)` is called).