### PR TITLE
Fix omission of man page

### DIFF
--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -66,8 +66,10 @@ if (GENERATE_MAN_PAGES)
     add_help2man_manpage (yubico-piv-tool.1 yubico-piv-tool)
 
     add_custom_target (yubico-piv-tool-man ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/yubico-piv-tool.1)
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/yubico-piv-tool.1" DESTINATION "${YKPIV_INSTALL_MAN_DIR}/man1")
 endif(GENERATE_MAN_PAGES)
 
+# If somehow a manpage was generated before configure started, install that too
 find_file(MAN_PAGE yubico-piv-tool.1 PATHS ${CMAKE_CURRENT_SOURCE_DIR})
 if(MAN_PAGE)
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/yubico-piv-tool.1" DESTINATION "${YKPIV_INSTALL_MAN_DIR}/man1")


### PR DESCRIPTION
It was omitting the man page upon first install, so in order to get the man page added to the installed set of files, one would have to run `cmake`, then run `make`, then run `cmake` again, then run `make install`.

This commit just hinges the installed file declaration on whether we want to generate man pages. If the man page generation fails, it'll still fail the build like before.