### PR TITLE
Bump SO_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set (yubico_piv_tool_VERSION_MAJOR 2)
 set (yubico_piv_tool_VERSION_MINOR 1)
 set (yubico_piv_tool_VERSION_PATCH 1)
 set (VERSION "${yubico_piv_tool_VERSION_MAJOR}.${yubico_piv_tool_VERSION_MINOR}.${yubico_piv_tool_VERSION_PATCH}")
-set (SO_VERSION 1)
+set (SO_VERSION 2)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 include(${CMAKE_SOURCE_DIR}/cmake/options.cmake)


### PR DESCRIPTION
ABI compatibility broke, as the symbol versioning scheme changed, so `SO_VERSION` needs to be increased. 
This presumably happened due to the switch to CMake.

Discovered while packaging v2.1.1 for Debian.