### PR TITLE
Close more minor memory leak

### DIFF
--- a/ykcs11/openssl_utils.c
+++ b/ykcs11/openssl_utils.c
@@ -770,8 +770,7 @@ CK_RV do_strip_DER_encoding_from_ECSIG(CK_BYTE_PTR data, CK_ULONG len, CK_ULONG 
 
   ECDSA_SIG_free(sig);
   return CKR_OK;
-
- strip_der_cleanup:
+strip_der_cleanup:
   ECDSA_SIG_free(sig);
   return rv;
 }

--- a/ykcs11/openssl_utils.c
+++ b/ykcs11/openssl_utils.c
@@ -768,14 +768,10 @@ CK_RV do_strip_DER_encoding_from_ECSIG(CK_BYTE_PTR data, CK_ULONG len, CK_ULONG 
     goto strip_der_cleanup;
   }
 
-  return CKR_OK;
-strip_der_cleanup:
   ECDSA_SIG_free(sig);
-  if(x != NULL) {
-    BN_free(x);
-  }
-  if(y != NULL) {
-    BN_free(y);
-  }
+  return CKR_OK;
+
+ strip_der_cleanup:
+  ECDSA_SIG_free(sig);
   return rv;
 }

--- a/ykcs11/tests/ykcs11_tests.c
+++ b/ykcs11/tests/ykcs11_tests.c
@@ -471,6 +471,7 @@ static void test_sign_eccp(CK_BYTE* key_params, CK_ULONG key_params_len, CK_ULON
     test_ec_sign_thorough(funcs, session, obj_pvtkey, CKM_ECDSA_SHA384, eck, key_len);
   }
 
+  EC_KEY_free(eck);
   destroy_test_objects(funcs, session, obj_pvtkey, N_SELECTED_KEYS);
   asrt(funcs->C_CloseSession(session), CKR_OK, "CloseSession");
   asrt(funcs->C_Finalize(NULL), CKR_OK, "FINALIZE");
@@ -670,6 +671,7 @@ static void test_import_eccp(CK_BYTE* key_params, CK_ULONG key_params_len, CK_UL
   test_ec_sign_simple(funcs, session, obj_pvtkey, n_keys, eck, key_len);
   test_ec_ecdh_simple(funcs, session, obj_pvtkey, n_keys, curve);
 
+  EC_KEY_free(eck);
   destroy_test_objects(funcs, session, obj_cert, n_keys);
   asrt(funcs->C_CloseSession(session), CKR_OK, "CloseSession");
   asrt(funcs->C_Finalize(NULL), CKR_OK, "FINALIZE");

--- a/ykcs11/tests/ykcs11_tests_util.c
+++ b/ykcs11/tests/ykcs11_tests_util.c
@@ -395,6 +395,8 @@ EC_KEY* import_ec_key(CK_FUNCTION_LIST_PTR funcs, CK_SESSION_HANDLE session, CK_
 
   asrt(funcs->C_Logout(session), CKR_OK, "Logout SO");
   free(pvt);
+  X509_free(cert);
+  EVP_PKEY_free(evp);
   return eck;
 }
 
@@ -873,6 +875,7 @@ void test_rsa_sign_thorough(CK_FUNCTION_LIST_PTR funcs, CK_SESSION_HANDLE sessio
         asrt(EVP_PKEY_verify_init(ctx) > 0, 1, "EVP_KEY_verify_init");
         asrt(EVP_PKEY_CTX_set_signature_md(ctx, NULL) > 0, 1, "EVP_PKEY_CTX_set_signature_md");
         asrt(EVP_PKEY_verify(ctx, sig, sig_len, hdata, hdata_len), 1, "EVP_PKEY_verify");
+        EVP_PKEY_CTX_free(ctx);
       }
       
       // Internal verification: Verify


### PR DESCRIPTION
and also remove a potential double free in the error path.