### PR TITLE
yubico-piv-tool: Put useful description in manpage

### DIFF
--- a/cmake/help2man.cmake
+++ b/cmake/help2man.cmake
@@ -30,9 +30,9 @@ IF (NOT HELP2MAN_LOCATION)
     message (FATAL_ERROR "Cannot find help2man. Please install it.")
 ENDIF ()
 
-MACRO (add_help2man_manpage file command)
+MACRO (add_help2man_manpage file command description)
     add_custom_command (OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${file}
-            COMMAND  ${HELP2MAN_LOCATION} ARGS -s1 -N -o ${CMAKE_CURRENT_SOURCE_DIR}/${file} ./${command}
+            COMMAND  ${HELP2MAN_LOCATION} ARGS -s1 -N -n ${description} -o ${CMAKE_CURRENT_SOURCE_DIR}/${file} ./${command}
             DEPENDS ${command}
             COMMENT "Building manpage for ${command}")
 ENDMACRO ()

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -66,7 +66,7 @@ install(
 
 if (GENERATE_MAN_PAGES)
     include (${CMAKE_SOURCE_DIR}/cmake/help2man.cmake)
-    add_help2man_manpage (yubico-piv-tool.1 yubico-piv-tool)
+    add_help2man_manpage (yubico-piv-tool.1 yubico-piv-tool "Tool for managing Personal Identity Verification credentials on Yubikeys")
 
     add_custom_target (yubico-piv-tool-man ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/yubico-piv-tool.1)
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/yubico-piv-tool.1" DESTINATION "${YKPIV_INSTALL_MAN_DIR}/man1")


### PR DESCRIPTION
`help2man`'s `-n` parameter takes a description of the command,
and is used in generating the `whatis` entry.

Without a description, it defaults to something worse-than-useless:
`manual page for yubico-piv-tool ${version}`.