### PR TITLE
Ignore and return CK_FALSE for CKA_SIGN_RECOVER

### DIFF
--- a/ykcs11/mechanisms.c
+++ b/ykcs11/mechanisms.c
@@ -709,6 +709,7 @@ CK_RV check_pvtkey_template(gen_info_t *gen, CK_MECHANISM_PTR mechanism, CK_ATTR
     case CKA_DECRYPT:
     case CKA_UNWRAP:
     case CKA_SIGN:
+    case CKA_SIGN_RECOVER:
     case CKA_PRIVATE:
     case CKA_TOKEN:
     case CKA_DERIVE:

--- a/ykcs11/objects.c
+++ b/ykcs11/objects.c
@@ -722,6 +722,13 @@ static CK_RV get_proa(ykcs11_slot_t *s, piv_obj_id_t obj, CK_ATTRIBUTE_PTR templ
     data = b_tmp;
     break;
 
+  case CKA_SIGN_RECOVER:
+    DBG("SIGN_RECOVER");
+    len = sizeof(CK_BBOOL);
+    b_tmp[0] = CK_FALSE;
+    data = b_tmp;
+    break;
+
   default:
     DBG("UNKNOWN ATTRIBUTE %lx (%lu)", template[0].type, template[0].type);
     template->ulValueLen = CK_UNAVAILABLE_INFORMATION;

--- a/ykcs11/tests/ykcs11_tests_util.c
+++ b/ykcs11/tests/ykcs11_tests_util.c
@@ -1332,6 +1332,7 @@ static void test_privkey_basic_attributes(CK_FUNCTION_LIST_PTR funcs, CK_SESSION
   CK_BBOOL obj_decrypt;
   CK_BBOOL obj_unwrap;
   CK_BBOOL obj_sign;
+  CK_BBOOL obj_sign_recover;
   CK_BBOOL obj_derive;
   CK_ULONG obj_modulus_bits;
   CK_BBOOL obj_always_authenticate;
@@ -1352,6 +1353,7 @@ static void test_privkey_basic_attributes(CK_FUNCTION_LIST_PTR funcs, CK_SESSION
     {CKA_DECRYPT, &obj_decrypt, sizeof(CK_BBOOL)},
     {CKA_UNWRAP, &obj_unwrap, sizeof(CK_BBOOL)},
     {CKA_SIGN, &obj_sign, sizeof(CK_BBOOL)},
+    {CKA_SIGN_RECOVER, &obj_sign_recover, sizeof(CK_BBOOL)},
     {CKA_DERIVE, &obj_derive, sizeof(CK_BBOOL)},
     {CKA_MODULUS_BITS, &obj_modulus_bits, sizeof(CK_ULONG)},
     {CKA_ALWAYS_AUTHENTICATE, &obj_always_authenticate, sizeof(CK_BBOOL)},
@@ -1362,7 +1364,7 @@ static void test_privkey_basic_attributes(CK_FUNCTION_LIST_PTR funcs, CK_SESSION
     {CKA_LABEL, obj_label, sizeof(obj_label)}
   };
 
-  asrt(funcs->C_GetAttributeValue(session, privkey, template, 16), CKR_OK, "GET BASIC ATTRIBUTES");
+  asrt(funcs->C_GetAttributeValue(session, privkey, template, 17), CKR_OK, "GET BASIC ATTRIBUTES");
   asrt(obj_class, CKO_PRIVATE_KEY, "CLASS");
   asrt(obj_token, CK_TRUE, "TOKEN");
   asrt(obj_private, CK_TRUE, "PRIVATE");
@@ -1375,6 +1377,7 @@ static void test_privkey_basic_attributes(CK_FUNCTION_LIST_PTR funcs, CK_SESSION
   asrt(obj_decrypt, CK_TRUE, "DECRYPT");
   asrt(obj_unwrap, CK_FALSE, "UNWRAP");
   asrt(obj_sign, CK_TRUE, "SIGN");
+  asrt(obj_sign_recover, CK_FALSE, "SIGN_RECOVER");
   asrt(obj_derive, CK_FALSE, "DERIVE");
   asrt(obj_modulus_bits, key_size, "MODULUS BITS");
   asrt(obj_always_authenticate, always_authenticate, "ALWAYS AUTHENTICATE");


### PR DESCRIPTION
See https://github.com/Yubico/yubico-piv-tool/issues/291