### PR TITLE
Handle no pubkey

### DIFF
--- a/ykcs11/objects.c
+++ b/ykcs11/objects.c
@@ -560,8 +560,8 @@ static CK_RV get_proa(ykcs11_slot_t *s, piv_obj_id_t obj, CK_ATTRIBUTE_PTR templ
   case CKA_ID:
     DBG("ID");
     len = sizeof(CK_BYTE);
-    ul_tmp = piv_objects[obj].sub_id;
-    data = (CK_BYTE_PTR) &ul_tmp;
+    b_tmp[0] = piv_objects[obj].sub_id;
+    data = b_tmp;
     break;
 
   case CKA_SENSITIVE:

--- a/ykcs11/openssl_utils.c
+++ b/ykcs11/openssl_utils.c
@@ -482,6 +482,9 @@ CK_RV do_store_pubk(ykcs11_x509_t *cert, ykcs11_pkey_t **key) {
 
 CK_KEY_TYPE do_get_key_type(ykcs11_pkey_t *key) {
 
+  if(!key) // EVP_PKEY_base_id doesn't handle NULL
+    return CKK_VENDOR_DEFINED; // Actually an error
+
   switch (EVP_PKEY_base_id(key)) {
   case EVP_PKEY_RSA:
     return CKK_RSA;

--- a/ykcs11/tests/ykcs11_tests.c
+++ b/ykcs11/tests/ykcs11_tests.c
@@ -81,9 +81,9 @@ static void get_functions() {
 
 static void init_connection() {
   asrt(funcs->C_Initialize(NULL), CKR_OK, "INITIALIZE");
-  CK_SLOT_ID pSlotList;
+  CK_SLOT_ID pSlotList[16];
   CK_ULONG pulCount = 16;
-  asrt(funcs->C_GetSlotList(true, &pSlotList, &pulCount), CKR_OK, "GETSLOTLIST");
+  asrt(funcs->C_GetSlotList(true, pSlotList, &pulCount), CKR_OK, "GETSLOTLIST");
 }
 
 static void test_lib_info() {


### PR DESCRIPTION
Handle segfault due to no public key being present in certain circumstance, such as importing a key to a slot that had no key when the session was opened. Also fixed a bug in tests causing stack overwrite if running tests with more than one YubiKey attached.