### PR TITLE
P11 attributes

### DIFF
--- a/ykcs11/mechanisms.c
+++ b/ykcs11/mechanisms.c
@@ -712,6 +712,13 @@ CK_RV check_pvtkey_template(gen_info_t *gen, CK_MECHANISM_PTR mechanism, CK_ATTR
       }
       break;
 
+    case CKA_EXTRACTABLE:
+      if (*((CK_BBOOL *)templ[i].pValue) != CK_FALSE) {
+        DBG("CKA_EXTRACTABLE must be FALSE or omitted");
+        return CKR_ATTRIBUTE_VALUE_INVALID;
+      }
+      break;
+
     case CKA_DECRYPT:
     case CKA_UNWRAP:
     case CKA_SIGN:

--- a/ykcs11/mechanisms.c
+++ b/ykcs11/mechanisms.c
@@ -706,6 +706,12 @@ CK_RV check_pvtkey_template(gen_info_t *gen, CK_MECHANISM_PTR mechanism, CK_ATTR
       break;
 
     case CKA_SENSITIVE:
+      if (*((CK_BBOOL *)templ[i].pValue) != CK_TRUE) {
+        DBG("CKA_SENSITIVE must be TRUE or omitted");
+        return CKR_ATTRIBUTE_VALUE_INVALID;
+      }
+      break;
+
     case CKA_DECRYPT:
     case CKA_UNWRAP:
     case CKA_SIGN:

--- a/ykcs11/objects.c
+++ b/ykcs11/objects.c
@@ -1583,10 +1583,16 @@ CK_RV check_create_ec_key(CK_ATTRIBUTE_PTR templ, CK_ULONG n, CK_BYTE_PTR id,
 
       break;
 
+    case CKA_SENSITIVE:
+      if (*((CK_BBOOL *)templ[i].pValue) != CK_TRUE) {
+        DBG("CKA_SENSITIVE must be TRUE or omitted");
+        return CKR_ATTRIBUTE_VALUE_INVALID;
+      }
+      break;
+
     case CKA_TOKEN:
     case CKA_LABEL:
     case CKA_SUBJECT:
-    case CKA_SENSITIVE:
     case CKA_DERIVE:
       // Ignore other attributes
       break;
@@ -1696,10 +1702,16 @@ CK_RV check_create_rsa_key(CK_ATTRIBUTE_PTR templ, CK_ULONG n, CK_BYTE_PTR id,
 
       break;
 
+    case CKA_SENSITIVE:
+      if (*((CK_BBOOL *)templ[i].pValue) != CK_TRUE) {
+        DBG("CKA_SENSITIVE must be TRUE or omitted");
+        return CKR_ATTRIBUTE_VALUE_INVALID;
+      }
+      break;
+
     case CKA_TOKEN:
     case CKA_LABEL:
     case CKA_SUBJECT:
-    case CKA_SENSITIVE:
     case CKA_DERIVE:
       // Ignore other attributes
       break;

--- a/ykcs11/objects.c
+++ b/ykcs11/objects.c
@@ -1590,6 +1590,13 @@ CK_RV check_create_ec_key(CK_ATTRIBUTE_PTR templ, CK_ULONG n, CK_BYTE_PTR id,
       }
       break;
 
+    case CKA_EXTRACTABLE:
+      if (*((CK_BBOOL *)templ[i].pValue) != CK_FALSE) {
+        DBG("CKA_EXTRACTABLE must be FALSE or omitted");
+        return CKR_ATTRIBUTE_VALUE_INVALID;
+      }
+      break;
+
     case CKA_TOKEN:
     case CKA_LABEL:
     case CKA_SUBJECT:
@@ -1705,6 +1712,13 @@ CK_RV check_create_rsa_key(CK_ATTRIBUTE_PTR templ, CK_ULONG n, CK_BYTE_PTR id,
     case CKA_SENSITIVE:
       if (*((CK_BBOOL *)templ[i].pValue) != CK_TRUE) {
         DBG("CKA_SENSITIVE must be TRUE or omitted");
+        return CKR_ATTRIBUTE_VALUE_INVALID;
+      }
+      break;
+
+    case CKA_EXTRACTABLE:
+      if (*((CK_BBOOL *)templ[i].pValue) != CK_FALSE) {
+        DBG("CKA_EXTRACTABLE must be FALSE or omitted");
         return CKR_ATTRIBUTE_VALUE_INVALID;
       }
       break;


### PR DESCRIPTION
Make both `CKA_SENSITIVE` and `CKA_EXTRACTABLE` settable, but also enforce that they are always respectively `CK_TRUE` and `CK_FALSE`.