### PR TITLE
Avoid header include guard conflict with OpenSSL 3

### DIFF
--- a/ykcs11/openssl_types.h
+++ b/ykcs11/openssl_types.h
@@ -28,8 +28,8 @@
  *
  */
 
-#ifndef OPENSSL_TYPES_H
-#define OPENSSL_TYPES_H
+#ifndef YKCS11_OPENSSL_TYPES_H
+#define YKCS11_OPENSSL_TYPES_H
 
 #include <openssl/bn.h>
 #include <openssl/x509.h>


### PR DESCRIPTION
OpenSSL 3.x ships an [`openssl/types.h`](https://github.com/openssl/openssl/blob/master/include/openssl/types.h#L10) header that's protected with an `OPENSSL_TYPES_H` include guard macro.  OpenSSL's headers fail to parse when `ykcs11/openssl_types.h` defines this symbol.

Switch the include guard for the file to `YKCS11_OPENSSL_TYPES_H` to prevent this from happening.