### PR TITLE
Compile cleanly with openssl 1.1 & 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ include(CheckCCompilerFlag)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+add_definitions(-DOPENSSL_API_COMPAT=0x10000000L)
+
 if(WIN32)
     add_definitions(-DWIN32_LEAN_AND_MEAN)
     set(_WIN32 ${WIN32})

--- a/ykcs11/mechanisms.c
+++ b/ykcs11/mechanisms.c
@@ -151,7 +151,7 @@ CK_RV sign_mechanism_init(ykcs11_session_t *session, ykcs11_pkey_t *key, CK_MECH
   }
 
   session->op_info.out_len = do_get_signature_size(key);
-  session->op_info.op.sign.rsa = EVP_PKEY_get0_RSA(key);
+  session->op_info.op.sign.rsa = (RSA*)EVP_PKEY_get0_RSA(key);
   session->op_info.op.sign.algorithm = do_get_key_algorithm(key);
 
   switch (session->op_info.mechanism) {
@@ -394,7 +394,7 @@ CK_RV verify_mechanism_init(ykcs11_session_t *session, ykcs11_pkey_t *key, CK_ME
       return CKR_MECHANISM_INVALID;
   }
 
-  ykcs11_rsa_t *rsa = EVP_PKEY_get0_RSA(key);
+  const ykcs11_rsa_t *rsa = EVP_PKEY_get0_RSA(key);
   CK_RSA_PKCS_PSS_PARAMS *pss = NULL;
 
   switch (session->op_info.mechanism) {

--- a/ykcs11/openssl_utils.c
+++ b/ykcs11/openssl_utils.c
@@ -574,7 +574,7 @@ CK_BYTE do_get_key_algorithm(ykcs11_pkey_t *key) {
 }
 
 CK_RV do_get_modulus(ykcs11_pkey_t *key, CK_BYTE_PTR data, CK_ULONG_PTR len) {
-  RSA *rsa = NULL;
+  const RSA *rsa = NULL;
   const BIGNUM *n = NULL;
 
   rsa = EVP_PKEY_get0_RSA(key);
@@ -593,7 +593,7 @@ CK_RV do_get_modulus(ykcs11_pkey_t *key, CK_BYTE_PTR data, CK_ULONG_PTR len) {
 
 CK_RV do_get_public_exponent(ykcs11_pkey_t *key, CK_BYTE_PTR data, CK_ULONG_PTR len) {
 
-  RSA *rsa = NULL;
+  const RSA *rsa = NULL;
   const BIGNUM *bn_e;
 
   rsa = EVP_PKEY_get0_RSA(key);
@@ -615,10 +615,10 @@ CK_RV do_get_public_exponent(ykcs11_pkey_t *key, CK_BYTE_PTR data, CK_ULONG_PTR 
 /* //SSL_load_error_strings(); */
 /*   fprintf(stderr, "ERROR %s\n", ERR_error_string(ERR_get_error(), NULL)); */
 CK_RV do_get_public_key(ykcs11_pkey_t *key, CK_BYTE_PTR data, CK_ULONG_PTR len) {
-  RSA *rsa = NULL;
+  const RSA *rsa = NULL;
   unsigned char *p;
 
-  EC_KEY *eck = NULL;
+  const EC_KEY *eck = NULL;
   const EC_GROUP *ecg; // Alternative solution is to get i2d_PUBKEY and manually offset
   const EC_POINT *ecp;
   point_conversion_form_t pcf = POINT_CONVERSION_UNCOMPRESSED;
@@ -673,7 +673,7 @@ CK_RV do_get_public_key(ykcs11_pkey_t *key, CK_BYTE_PTR data, CK_ULONG_PTR len) 
 }
 
 CK_RV do_get_curve_parameters(ykcs11_pkey_t *key, CK_BYTE_PTR data, CK_ULONG_PTR len) {
-  EC_KEY *eck = NULL;
+  const EC_KEY *eck = NULL;
   const EC_GROUP *ecg;
   unsigned char *p;
 


### PR DESCRIPTION
The method API has subtle differences in OpenSSL 3 vs 1.1 which required a rewrite, but the new code works for both versions