### PR TITLE
[ykcs11/tests] fix use-after-free warning in gcc 12

### DIFF
--- a/ykcs11/tests/ykcs11_tests_util.c
+++ b/ykcs11/tests/ykcs11_tests_util.c
@@ -1143,6 +1143,7 @@ void test_rsa_decrypt(CK_FUNCTION_LIST_PTR funcs, CK_SESSION_HANDLE session, CK_
       asrt(dec_len, data_len, "DECRYPTED DATA LEN");
       asrt(memcmp(data, dec, dec_len), 0, "DECRYPTED DATA");
       free(dec);
+      dec = NULL;
 
       // Decrypt Update
       asrt(funcs->C_DecryptInit(session, &mech, obj_pvtkey[i]), CKR_OK, "DECRYPT INIT");


### PR DESCRIPTION
gcc 12 includes a new `-Wuse-after-free` warning mode that detects use
of variables after a call to `free()`. While the use of this variable is
not in fact a use-after-free, it is more correct to not reuse the `dec`
variable or explicitly set it to `NULL` after calling `free`.

This is not a security bug.

Signed-Off-By: Dan Fuhry <dan@fuhry.com>