### PR TITLE
Revisit MSVC warnings supression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,26 +70,15 @@ if(MSVC)
     endif()
     if(SUPRESS_MSVC_WARNINGS)
         set(MSVC_DISABLED_WARNINGS_LIST
-            "C4200" # nonstandard extension used: zero-sized array in struct/union;
-            "C4204" # nonstandard extension used: non-constant aggregate initializer;
             "C4706" # assignment within conditional expression;
             "C4996" # The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name
-
-            "C4473" # Not enough arguments passed for format string placeholders
             "C4244" # Conversion from 'int' to 'unsigned char', possible loss of data
             "C4152" # Nonstandard extension, function/data pointer conversion in expression (openssl/applink.c)
             "C4068" # Unknown pragma
-            "C4701" # Potentially uninitialized local variable
-            "C4703" # Potentially uninitialized local pointer
             "C4100" # 'param': unreferenced formal parameter (unsupported pkcs11 functions)
-            "C4221" # Nonstandard extension used: 'pValue': cannot be initialized using address of automatic variable (ykcs11_tests_util)
-            "C4057" # 'const char *' differs in indirection to slightly different base types from 'const CK_CHAR_PTR' (ykcs11 tests)
-            "C4245" # Conversion from 'int' to 'CK_ULONG' (ykcs11 tests)
-            "C4013" # '_getpid' undefined; assuming extern returning int (ykcs11/utils.c)
-            "C4702" # Unreachable code (mechanisms.c:is_RSA_mechanism)
-            "C4133" # Incompatible types: from 'ykpiv_rc' (enum) to 'int'
             "C4267" # Conversion from 'size_t' to 'CK_ULONG'
             "C4312" # Conversion from 'unsigned int' to 'void *' of greater size (ykcs11/utils.c:noop_create_mutex)
+            "C5105" # Macro expansion producing 'defined' has undefined behavior
             )
         # The construction in the following 3 lines was taken from LibreSSL's
         # CMakeLists.txt.

--- a/lib/internal.c
+++ b/lib/internal.c
@@ -84,10 +84,6 @@ char *_strip_ws(char *sz);
 setting_bool_t _get_bool_config(const char *sz_setting);
 setting_bool_t _get_bool_env(const char *sz_setting);
 
-/* log */
-
-const char szLOG_SOURCE[] = "YubiKey PIV Library";
-
 /*
 ** Methods
 */
@@ -133,7 +129,7 @@ cipher_rc cipher_encrypt(cipher_key key, const unsigned char* in, uint32_t inlen
 	if (key == NULL) {
     return CIPHER_MEMORY_ERROR;
   }
-	if(!BCRYPT_SUCCESS(BCryptEncrypt(key->hKey, (PUCHAR)in, inlen, NULL, NULL, 0, out, *outlen, outlen, 0))) {
+	if(!BCRYPT_SUCCESS(BCryptEncrypt(key->hKey, (PUCHAR)in, inlen, NULL, NULL, 0, out, *outlen, (PULONG)outlen, 0))) {
     return CIPHER_INVALID_PARAMETER;
   }
   return CIPHER_OK;
@@ -143,7 +139,7 @@ cipher_rc cipher_decrypt(cipher_key key, const unsigned char* in, uint32_t inlen
 	if (key == NULL) {
     return CIPHER_MEMORY_ERROR;
   }
-	if(!BCRYPT_SUCCESS(BCryptDecrypt(key->hKey, (PUCHAR)in, inlen, NULL, NULL, 0, out, *outlen, outlen, 0))) {
+	if(!BCRYPT_SUCCESS(BCryptDecrypt(key->hKey, (PUCHAR)in, inlen, NULL, NULL, 0, out, *outlen, (PULONG)outlen, 0))) {
     return CIPHER_INVALID_PARAMETER;
   }
   return CIPHER_OK;
@@ -466,7 +462,7 @@ setting_bool_t setting_get_bool(const char *sz_setting, bool def) {
 
 /* logging */
 
-void yc_log_event(uint32_t id, yc_log_level_t level, const char * sz_format, ...) {
+void yc_log_event(const char *sz_source, uint32_t id, yc_log_level_t level, const char * sz_format, ...) {
   char rgsz_message[4096] = {0};
   va_list vl;
 
@@ -501,7 +497,7 @@ void yc_log_event(uint32_t id, yc_log_level_t level, const char * sz_format, ...
       break;
   }
 
-  if (!(hLog = RegisterEventSourceA(NULL, szLOG_SOURCE))) {
+  if (!(hLog = RegisterEventSourceA(NULL, sz_source))) {
     goto Cleanup;
   }
 
@@ -553,7 +549,7 @@ void yc_log_event(uint32_t id, yc_log_level_t level, const char * sz_format, ...
      goto Cleanup;
    }
 
-   openlog(szLOG_SOURCE, LOG_PID | LOG_NDELAY, LOG_USER);
+   openlog(sz_source, LOG_PID | LOG_NDELAY, LOG_USER);
    syslog(priority, "%s", rgsz_message);
    closelog();
 

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -235,7 +235,7 @@ typedef enum _yc_log_level_t {
   YC_LOG_LEVEL_DEBUG
 } yc_log_level_t;
 
-void yc_log_event(uint32_t id, yc_log_level_t level, const char *sz_format, ...);
+void yc_log_event(const char *sz_source, uint32_t id, yc_log_level_t level, const char *sz_format, ...);
 
 void _ykpiv_set_debug(void (*dbg)(const char *));
 void _ykpiv_debug(const char *file, int line, const char *func, int lvl, const char *fmt, ...);

--- a/lib/util.c
+++ b/lib/util.c
@@ -788,7 +788,7 @@ ykpiv_rc ykpiv_util_generate_key(ykpiv_state *state, uint8_t slot, uint8_t algor
       }
 
       DBG(sz_roca_format, state->serial, psz_msg);
-      yc_log_event(1, setting_roca.value ? YC_LOG_LEVEL_WARN : YC_LOG_LEVEL_ERROR, sz_roca_format, state->serial, psz_msg);
+      yc_log_event("YubiKey PIV Library", 1, setting_roca.value ? YC_LOG_LEVEL_WARN : YC_LOG_LEVEL_ERROR, sz_roca_format, state->serial, psz_msg);
 
       if (!setting_roca.value) {
         return YKPIV_NOT_SUPPORTED;

--- a/lib/ykpiv.c
+++ b/lib/ykpiv.c
@@ -1864,7 +1864,7 @@ ykpiv_rc ykpiv_import_private_key(ykpiv_state *state, const unsigned char key, u
   unsigned char templ[] = {0, YKPIV_INS_IMPORT_KEY, algorithm, key};
   unsigned char data[261] = {0};
   unsigned long recv_len = sizeof(data);
-  unsigned elem_len;
+  unsigned elem_len = 0;
   int sw = 0;
   const unsigned char *params[5] = {0};
   size_t lens[5] = {0};

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -1283,7 +1283,7 @@ static bool verify_pin(ykpiv_state *state, const char *pin) {
 static bool change_pin(ykpiv_state *state, enum enum_action action, const char *pin,
     const char *new_pin) {
   const char *name = action == action_arg_changeMINUS_pin ? "pin" : "puk";
-  int (*op)(ykpiv_state *state, const char * puk, size_t puk_len,
+  ykpiv_rc (*op)(ykpiv_state *state, const char * puk, size_t puk_len,
             const char * new_pin, size_t new_pin_len, int *tries) = ykpiv_change_pin;
   size_t pin_len;
   size_t new_len;

--- a/ykcs11/mechanisms.c
+++ b/ykcs11/mechanisms.c
@@ -76,9 +76,6 @@ static CK_BBOOL is_RSA_mechanism(CK_MECHANISM_TYPE m) {
   default:
     return CK_FALSE;
   }
-
-  // Not reached
-  return CK_FALSE;
 }
 
 static const ykcs11_md_t* EVP_MD_by_mechanism(CK_MECHANISM_TYPE m) {
@@ -1020,7 +1017,7 @@ CK_RV decrypt_mechanism_final(ykcs11_session_t *session, CK_BYTE_PTR data, CK_UL
     return CKR_FUNCTION_FAILED;
   }
 
-  if(cb_len > *data_len) {
+  if((CK_ULONG)cb_len > *data_len) {
     DBG("Unpadded data too large (%d) for provided buffer (%lu)", cb_len, *data_len);
     *data_len = 0;
     return CKR_BUFFER_TOO_SMALL;

--- a/ykcs11/openssl_utils.c
+++ b/ykcs11/openssl_utils.c
@@ -359,7 +359,7 @@ CK_RV do_create_empty_cert(CK_BYTE_PTR in, CK_ULONG in_len, CK_ULONG algorithm,
     goto create_empty_cert_cleanup;
   }
 
-  if (len > *out_len) {
+  if ((CK_ULONG)len > *out_len) {
     rv = CKR_BUFFER_TOO_SMALL;
     goto create_empty_cert_cleanup;
   }
@@ -724,7 +724,7 @@ CK_RV do_apply_DER_encoding_to_ECSIG(CK_BYTE_PTR signature, CK_ULONG_PTR signatu
     goto adete_out;
   }
 
-  if (len > buf_size) {
+  if ((CK_ULONG)len > buf_size) {
     rv = CKR_BUFFER_TOO_SMALL;
     goto adete_out;
   }
@@ -755,7 +755,7 @@ static int BN_bn2bin_fixed(const BIGNUM *bn, CK_BYTE_PTR out, CK_ULONG len) {
   int actual = BN_bn2bin(bn, buf);
   if(actual <= 0)
     return actual;
-  if(actual < len) {
+  if((CK_ULONG)actual < len) {
     memset(out,  0, len - actual);
     memcpy(out + len - actual, buf, actual);
   } else {

--- a/ykcs11/token.c
+++ b/ykcs11/token.c
@@ -171,7 +171,7 @@ CK_RV get_token_serial(ykpiv_state *state, CK_CHAR_PTR str, CK_ULONG len) {
   if(actual < 0)
     return CKR_FUNCTION_FAILED;
 
-  if(actual >= len)
+  if((CK_ULONG)actual >= len)
     return CKR_BUFFER_TOO_SMALL;
 
   memstrcpy(str, len, buf);
@@ -192,7 +192,7 @@ CK_RV get_token_label(ykpiv_state *state, CK_CHAR_PTR str, CK_ULONG len) {
   if(actual < 0)
     return CKR_FUNCTION_FAILED;
 
-  if(actual >= len)
+  if((CK_ULONG)actual >= len)
     return CKR_BUFFER_TOO_SMALL;
 
   memstrcpy(str, len, buf);
@@ -485,7 +485,7 @@ CK_RV token_generate_key(ykpiv_state *state, gen_info_t *gen, CK_BYTE key, CK_BY
   *certptr++ = TAG_CERT_LRC;
   *certptr++ = 0;
 
-  if(*cert_len < certptr - data) {
+  if(*cert_len < (CK_ULONG)(certptr - data)) {
     DBG("Certificate buffer too small.");
     return CKR_BUFFER_TOO_SMALL;
   }

--- a/ykcs11/utils.c
+++ b/ykcs11/utils.c
@@ -33,6 +33,7 @@
 #ifdef _WIN32
 #include <windows.h>
 #include <winsock.h>
+#include <process.h>
 #else
 #include <unistd.h>
 #include <pthread.h>


### PR DESCRIPTION
Remove as many supressed warnings as feasible, fixing some warnings in code instead