### PR TITLE
Better error messages and truncate data for ECC signatures

### DIFF
--- a/lib/ykpiv.c
+++ b/lib/ykpiv.c
@@ -1195,7 +1195,8 @@ static ykpiv_rc _general_authenticate(ykpiv_state *state,
 	      key_len = 48;
       }
       if(!decipher && in_len > key_len) {
-	      return YKPIV_SIZE_ERROR;
+        DBG("Data to sign truncated to EC key length (%zu bytes)", key_len);
+        in_len = key_len;
       } else if(decipher && in_len != (key_len * 2) + 1) {
 	      return YKPIV_SIZE_ERROR;
       }
@@ -1222,6 +1223,8 @@ static ykpiv_rc _general_authenticate(ykpiv_state *state,
     DBG("Sign command failed with code %x.", sw);
     if (sw == SW_ERR_SECURITY_STATUS)
       return YKPIV_AUTHENTICATION_ERROR;
+    else if(sw == SW_ERR_INCORRECT_PARAM)
+      return YKPIV_ARGUMENT_ERROR;
     else if(sw != SW_SUCCESS)
       return YKPIV_GENERIC_ERROR;
   }

--- a/ykcs11/mechanisms.c
+++ b/ykcs11/mechanisms.c
@@ -291,22 +291,6 @@ CK_RV sign_mechanism_final(ykcs11_session_t *session, CK_BYTE_PTR sig, CK_ULONG_
       break;
   }
 
-  // Truncate too long ECDSA signature data as per PKCS11 2.40 section 2.3.6
-  switch(session->op_info.op.sign.algorithm) {
-    case YKPIV_ALGO_ECCP256:
-      if (session->op_info.buf_len > 32) {
-        DBG("Truncated %lu bytes ECDSA signature data to 32 bytes for mechanism 0x%lx", session->op_info.buf_len, session->op_info.mechanism);
-        session->op_info.buf_len = 32;
-      }
-      break;
-    case YKPIV_ALGO_ECCP384:
-      if (session->op_info.buf_len > 48) {
-        DBG("Truncated %lu bytes ECDSA signature data to 48 bytes for mechanism 0x%lx", session->op_info.buf_len, session->op_info.mechanism);
-        session->op_info.buf_len = 48;
-      }
-      break;
-  }
-
   // Sign with PIV
   unsigned char sigbuf[256] = {0};
   size_t siglen = sizeof(sigbuf);


### PR DESCRIPTION
Related to https://github.com/Yubico/yubico-piv-tool/issues/412