### PR TITLE
Fix buffer size when testing RSA4096 decipher

### DIFF
--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -2139,7 +2139,7 @@ static bool test_decipher(ykpiv_state *state, enum enum_slot slot,
     if(YKPIV_IS_RSA(algorithm)) {
       unsigned char secret[32] = {0};
       unsigned char secret2[32] = {0};
-      unsigned char data[256] = {0};
+      unsigned char data[512] = {0};
       int len;
       size_t len2 = sizeof(data);
       RSA *rsa = EVP_PKEY_get1_RSA(pubkey);


### PR DESCRIPTION
The original buffer is not large enough for RSA4096, causing an error:
```
DBG ykpiv.c:1299 (_general_authenticate): Wrong size on output buffer.
RSA decrypt failed!
```
