### PR TITLE
tests: Avoid passing incompatible arguments to OpenSSL

### DIFF
--- a/ykcs11/tests/ykcs11_tests_util.c
+++ b/ykcs11/tests/ykcs11_tests_util.c
@@ -307,7 +307,7 @@ EVP_PKEY* import_edkey(CK_FUNCTION_LIST_3_0_PTR funcs, CK_SESSION_HANDLE session
   CK_BYTE     id = 1;
   CK_BYTE     value_c[255] = {0};
   CK_CHAR     pvt[255] = {0};
-  CK_ULONG    pvt_len  = sizeof(pvt);
+  size_t    pvt_len  = sizeof(pvt);
 
 
   CK_ATTRIBUTE privateKeyTemplate[] = {
@@ -375,7 +375,7 @@ void import_x25519key(CK_FUNCTION_LIST_3_0_PTR funcs, CK_SESSION_HANDLE session,
   CK_ULONG    kt = CKK_EC_MONTGOMERY;
   CK_BYTE     id = 1;
   CK_CHAR     pvt[255] = {0};
-  CK_ULONG    pvt_len  = sizeof(pvt);
+  size_t    pvt_len  = sizeof(pvt);
 
 
   CK_ATTRIBUTE privateKeyTemplate[] = {


### PR DESCRIPTION
on i686, the ULONG is not the same size as size_t and the build fails with errors like:
```
ykcs11/tests/ykcs11_tests_util.c:332:50: error: passing argument 3 of ‘EVP_PKEY_get_raw_private_key’ from incompatible pointer type [-Wincompatible-pointer-types]
  332 |   asrt(EVP_PKEY_get_raw_private_key(ed_key, pvt, &pvt_len), 1, "EXTRACTING PRIVATE ED25519 KEY");
      |                                                  ^~~~~~~~
      |                                                  |
      |                                                  CK_ULONG * {aka long unsigned int *}
ykcs11/tests/ykcs11_tests_util.c:64:49: note: in definition of macro ‘asrt’
   64 | #define asrt(c, e, m) _asrt(__FILE__, __LINE__, c, e, m);
      |                                                 ^
In file included from /usr/include/openssl/x509.h:29,
                 from /builddir/build/BUILD/yubico-piv-tool-2.6.0-build/yubico-piv-tool-2.6.0/ykcs11/tests/ykcs11_tests_util.c:39:
/usr/include/openssl/evp.h:1843:42: note: expected ‘size_t *’ {aka ‘unsigned int *’} but argument is of type ‘CK_ULONG *’ {aka ‘long unsigned int *’}
 1843 |                                  size_t *len);
      |                                  ~~~~~~~~^~~
ykcs11/tests/ykcs11_tests_util.c: In function ‘import_x25519key’:
ykcs11/tests/ykcs11_tests_util.c:393:47: error: passing argument 3 of ‘EVP_PKEY_get_raw_private_key’ from incompatible pointer type [-Wincompatible-pointer-types]
  393 |   asrt(EVP_PKEY_get_raw_private_key(key, pvt, &pvt_len), 1, "EXTRACTING PRIVATE ED25519 KEY");
      |                                               ^~~~~~~~
      |                                               |
      |                                               CK_ULONG * {aka long unsigned int *}
yubico-piv-tool-2.6.0/ykcs11/tests/ykcs11_tests_util.c:64:49: note: in definition of macro ‘asrt’
   64 | #define asrt(c, e, m) _asrt(__FILE__, __LINE__, c, e, m);
      |                                                 ^
/usr/include/openssl/evp.h:1843:42: note: expected ‘size_t *’ {aka ‘unsigned int *’} but argument is of type ‘CK_ULONG *’ {aka ‘long unsigned int *’}
 1843 |                                  size_t *len);
      |                                  ~~~~~~~~^~~
```
Changing the type to size_t and converting the value back to ulong should be safe when assigning them to the pkcs11 structures.