### PR TITLE
changing to codeql@v3 as v2 is being deprecated

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,11 +18,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
 
     - run: |
         sudo apt install libpcsclite-dev check gengetopt help2man openssl opensc
@@ -30,4 +30,4 @@ jobs:
         cmake .. -DVERBOSE_CMAKE=ON && make
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
CodeQL is deprecating v2 on December 5th. This PR merely bumps to v3. The action is verified to run.

background: https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/