### PR TITLE
Honor hash function set for RSA PKCS1 OAEP encryption

### DIFF
--- a/ykcs11/openssl_utils.c
+++ b/ykcs11/openssl_utils.c
@@ -71,23 +71,28 @@ CK_RV do_rsa_encrypt(ykcs11_pkey_t *key, int padding, const ykcs11_md_t* oaep_md
     }
   }
 
-  if(oaep_md != NULL && oaep_mgf1 != NULL && oaep_label != NULL) {
-    if(EVP_PKEY_CTX_set_rsa_oaep_md(ctx, oaep_md) >= 0) {
-      rv = CKR_FUNCTION_FAILED;
-      goto rsa_enc_cleanup;
-    }
-    
-    if(EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, oaep_mgf1) >= 0) {
-      rv = CKR_FUNCTION_FAILED;
-      goto rsa_enc_cleanup;
-    }
 
-    if(EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, oaep_label, oaep_label_len) >= 0) {
+  if(oaep_md != NULL) {
+    if(EVP_PKEY_CTX_set_rsa_oaep_md(ctx, oaep_md) <= 0) {
       rv = CKR_FUNCTION_FAILED;
       goto rsa_enc_cleanup;
     }
   }
- 
+  
+  if (oaep_mgf1 != NULL) {
+    if(EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, oaep_mgf1) <= 0) {
+      rv = CKR_FUNCTION_FAILED;
+      goto rsa_enc_cleanup;
+    }
+  }
+
+  if (oaep_label != NULL) {
+    if(EVP_PKEY_CTX_set0_rsa_oaep_label(ctx, oaep_label, oaep_label_len) <= 0) {
+      rv = CKR_FUNCTION_FAILED;
+      goto rsa_enc_cleanup;
+    }
+  }
+   
   size_t cbLen = *enc_len;
   if(EVP_PKEY_encrypt(ctx, enc, &cbLen, data, data_len) <= 0) {
     rv = CKR_FUNCTION_FAILED;


### PR DESCRIPTION
[Here](https://github.com/Yubico/yubico-piv-tool/blob/ab53895333cb3fd3147cb67d25d1d1b6c140c765/ykcs11/openssl_utils.c#L74) 

`  if(oaep_md != NULL && oaep_mgf1 != NULL && oaep_label != NULL) {`

a hash for the RSA OAEP encryption is set only if every parameter isn't null.

When oaep_label is null, OpenSSL properly encrypts the message and the encrypted message is properly decrypted by OpenSSL and the token. However, if I am encrypting the message with the token, ykcs11 doesn't set specified mgf1 and md parameters, thus the default SHA1/MGF_SHA1 scheme seems to kick in, and decrypting the message with the same parameters used for encryption fails.

Steps to reproduce:

```shell
dd if=/dev/zero of=zero190.bin bs=1 count=190

echo "Producing effectively SHA1 message, even though asked for SHA256"
$PKCS_TOOL --module ./build/ykcs11/libykcs11.dylib \
    -m "RSA-PKCS-OAEP" --encrypt --hash-algorithm "SHA256" --input-file zero190.bin --output-file zero190.bin.enc.master

echo "Decryption fails"
$PKCS_TOOL --module ./build/ykcs11/libykcs11.dylib \
    -m "RSA-PKCS-OAEP" --decrypt --hash-algorithm "SHA256" --input-file zero190.bin.enc.master --output-file zero190.bin.dec.master.256

echo "Decryption succeeds"
~/projects/bluekey/OpenSC/src/tools/pkcs11-tool --module ./build/ykcs11/libykcs11.dylib \
    -m "RSA-PKCS-OAEP" --decrypt --hash-algorithm "SHA-1"  --input-file zero190.bin.enc.master --output-file zero190.bin.dec.master.1


echo "Fixed version encrypts propely"
$PKCS_TOOL --module ./build.fix/ykcs11/libykcs11.dylib \
    -m "RSA-PKCS-OAEP" --encrypt --hash-algorithm "SHA256" --input-file zero190.bin --output-file zero190.bin.enc.fix

echo "This one succeeds"
$PKCS_TOOL --module ./build.fix/ykcs11/libykcs11.dylib \
    -m "RSA-PKCS-OAEP" --decrypt --hash-algorithm "SHA256" --input-file zero190.bin.enc.fix --output-file zero190.bin.dec.fix.256

echo "This one fails as expected"
$PKCS_TOOL --module ./build.fix/ykcs11/libykcs11.dylib \
    -m "RSA-PKCS-OAEP" --decrypt --hash-algorithm "SHA-1"  --input-file zero190.bin.enc.fix --output-file zero190.bin.dec.fix.1
```


```
Producing effectively SHA1 message, even though asked for SHA256

Using slot 0 with a present token (0x0)
Logging in to "YubiKey PIV #0".
Please enter User PIN: 
Using encrypt algorithm RSA-PKCS-OAEP
mgf not set, defaulting to MGF1-SHA256
OAEP parameters: hashAlg=SHA256, mgf=MGF1-SHA256, source_type=1, source_ptr=0x0, source_len=0


Decryption fails

Using slot 0 with a present token (0x0)
Logging in to "YubiKey PIV #0".
Please enter User PIN: 
Using decrypt algorithm RSA-PKCS-OAEP
mgf not set, defaulting to MGF1-SHA256
OAEP parameters: hashAlg=SHA256, mgf=MGF1-SHA256, source_type=1, source_ptr=0x0, source_len=0
error: PKCS11 function C_DecryptFinal failed: rv = CKR_FUNCTION_FAILED (0x6)
Aborting.


Decryption succeeds

Using slot 0 with a present token (0x0)
Logging in to "YubiKey PIV #0".
Please enter User PIN: 
Using decrypt algorithm RSA-PKCS-OAEP
mgf not set, defaulting to MGF1-SHA1
OAEP parameters: hashAlg=SHA-1, mgf=MGF1-SHA1, source_type=1, source_ptr=0x0, source_len=0


Fixed version encrypts propely

Using slot 0 with a present token (0x0)
Logging in to "YubiKey PIV #0".
Please enter User PIN: 
Using encrypt algorithm RSA-PKCS-OAEP
mgf not set, defaulting to MGF1-SHA256
OAEP parameters: hashAlg=SHA256, mgf=MGF1-SHA256, source_type=1, source_ptr=0x0, source_len=0


This one succeeds

Using slot 0 with a present token (0x0)
Logging in to "YubiKey PIV #0".
Please enter User PIN: 
Using decrypt algorithm RSA-PKCS-OAEP
mgf not set, defaulting to MGF1-SHA256
OAEP parameters: hashAlg=SHA256, mgf=MGF1-SHA256, source_type=1, source_ptr=0x0, source_len=0


This one fails as expected

Using slot 0 with a present token (0x0)
Logging in to "YubiKey PIV #0".
Please enter User PIN: 
Using decrypt algorithm RSA-PKCS-OAEP
mgf not set, defaulting to MGF1-SHA1
OAEP parameters: hashAlg=SHA-1, mgf=MGF1-SHA1, source_type=1, source_ptr=0x0, source_len=0
error: PKCS11 function C_DecryptFinal failed: rv = CKR_FUNCTION_FAILED (0x6)
Aborting.
```