### PR TITLE
Avoid sha1 where it is arbitrarily chosen

### DIFF
--- a/ykcs11/openssl_utils.c
+++ b/ykcs11/openssl_utils.c
@@ -290,7 +290,7 @@ CK_RV do_sign_empty_cert(const char *cn, ykcs11_pkey_t *pubkey, ykcs11_pkey_t *p
   X509_gmtime_adj(X509_get_notBefore(*cert), 0);
   X509_gmtime_adj(X509_get_notAfter(*cert), 0);
   X509_set_pubkey(*cert, pubkey);
-  if (X509_sign(*cert, pvtkey, EVP_sha1()) <= 0) {
+  if (X509_sign(*cert, pvtkey, EVP_sha256()) <= 0) {
     return CKR_GENERAL_ERROR;
   }
   return CKR_OK;

--- a/ykcs11/tests/ykcs11_tests_util.c
+++ b/ykcs11/tests/ykcs11_tests_util.c
@@ -505,7 +505,7 @@ EC_KEY* import_ec_key(CK_FUNCTION_LIST_3_0_PTR funcs, CK_SESSION_HANDLE session,
   if (X509_set_pubkey(cert, evp) == 0)
     exit(EXIT_FAILURE);
 
-  if (X509_sign(cert, evp, EVP_sha1()) == 0)
+  if (X509_sign(cert, evp, EVP_sha256()) == 0)
     exit(EXIT_FAILURE);
 
   CK_ULONG cert_len;
@@ -673,7 +673,7 @@ void import_rsa_key(CK_FUNCTION_LIST_3_0_PTR funcs, CK_SESSION_HANDLE session, i
   if (X509_set_pubkey(cert, *evp) == 0)
     exit(EXIT_FAILURE);
 
-  if (X509_sign(cert, *evp, EVP_sha1()) == 0)
+  if (X509_sign(cert, *evp, EVP_sha256()) == 0)
     exit(EXIT_FAILURE);
 
   CK_ULONG cert_len;


### PR DESCRIPTION
Sha1 has been deprecated in some distros, avoid it where easily doable. Should address https://github.com/Yubico/yubico-piv-tool/issues/532