### PR TITLE
Ykmd 5.0 SCP11b/MSVC updates

### DIFF
--- a/aes_cmac/aes.c
+++ b/aes_cmac/aes.c
@@ -37,7 +37,7 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
-#include <ntstatus.h>
+#define STATUS_SUCCESS 0
 #endif
 
 #ifdef _WIN32
@@ -263,13 +263,13 @@ int aes_set_key(const uint8_t *key, uint32_t key_len, unsigned char key_algo, ae
   }
 
   if (!BCRYPT_SUCCESS(status = import_key(ctx->hAlgCBC, &(ctx->hKeyCBC),
-                                          &(ctx->pbKeyCBCObj), ctx->cbKeyObj,
+                                          &(ctx->pbKeyCBCObj), (DWORD)ctx->cbKeyObj,
                                           key, key_len))) {
     return -2;
   }
 
   if (!BCRYPT_SUCCESS(status = import_key(ctx->hAlgECB, &(ctx->hKeyECB),
-                                          &(ctx->pbKeyECBObj), ctx->cbKeyObj,
+                                          &(ctx->pbKeyECBObj), (DWORD)ctx->cbKeyObj,
                                           key, key_len))) {
     return -3;
   }
@@ -347,8 +347,8 @@ int aes_cbc_encrypt(const uint8_t *in, uint32_t in_len, uint8_t *out, uint32_t *
   NTSTATUS status = STATUS_SUCCESS;
   ULONG cbResult = 0;
 
-  if (!BCRYPT_SUCCESS(status = BCryptEncrypt(ctx->hKeyCBC, (PUCHAR) in, in_len,
-                                             NULL, iv, iv_len, out,
+  if (!BCRYPT_SUCCESS(status = BCryptEncrypt(ctx->hKeyCBC, (PUCHAR)in, in_len,
+                                             NULL, (PUCHAR)iv, iv_len, out,
                                              in_len, &cbResult, 0))) {
     return -1;
   }
@@ -373,8 +373,8 @@ int aes_cbc_decrypt(const uint8_t *in, uint32_t in_len, uint8_t *out, uint32_t *
   NTSTATUS status = STATUS_SUCCESS;
   ULONG cbResult = 0;
 
-  if (!BCRYPT_SUCCESS(status = BCryptDecrypt(ctx->hKeyCBC, (PUCHAR) in, in_len,
-                                             NULL, iv, iv_len, out,
+  if (!BCRYPT_SUCCESS(status = BCryptDecrypt(ctx->hKeyCBC, (PUCHAR)in, in_len,
+                                             NULL, (PUCHAR)iv, iv_len, out,
                                              in_len, &cbResult, 0))) {
     return -1;
   }

--- a/aes_cmac/aes.h
+++ b/aes_cmac/aes.h
@@ -35,6 +35,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include <bcrypt.h>
 #else
 #include <openssl/evp.h>
 #endif

--- a/aes_cmac/aes.h
+++ b/aes_cmac/aes.h
@@ -35,8 +35,6 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#include <bcrypt.h>
-#include <ntstatus.h>
 #else
 #include <openssl/evp.h>
 #endif

--- a/lib/ecdh.c
+++ b/lib/ecdh.c
@@ -61,7 +61,9 @@ void ecdh_init(void) {
   }
 
   EnterCriticalSection(&cs);
-  (void)BCryptOpenAlgorithmProvider(&(curves[1]), BCRYPT_ECDH_P256_ALGORITHM, NULL, 0);
+  if (!curves[1]) {
+    (void)BCryptOpenAlgorithmProvider(&(curves[1]), BCRYPT_ECDH_P256_ALGORITHM, NULL, 0);
+  }
   ref_count++;
   LeaveCriticalSection(&cs);
 }

--- a/lib/ecdh.h
+++ b/lib/ecdh.h
@@ -55,6 +55,13 @@ int YH_INTERNAL ecdh_calculate_secret(int curve, const uint8_t *privkey,
                                       size_t cb_privkey, const uint8_t *pubkey,
                                       size_t cb_pubkey, uint8_t *secret,
                                       size_t cb_secret);
+#ifdef _WIN32
+void YH_INTERNAL ecdh_init(void);
+void YH_INTERNAL ecdh_done(void);
+#else
+#define ecdh_init()
+#define ecdh_done()
+#endif
 
 #ifdef __cplusplus
 }

--- a/lib/error.c
+++ b/lib/error.c
@@ -60,6 +60,7 @@ static const err_t errors[] = {
   ERR (YKPIV_RANGE_ERROR, "Range error"),
   ERR (YKPIV_NOT_SUPPORTED, "Not supported"),
   ERR (YKPIV_PCSC_SERVICE_ERROR, "PCSC service not available"),
+  ERR (YKPIV_CONDITION_ERROR, "Conditions not met to use command"),
 };
 
 /**

--- a/lib/internal.c
+++ b/lib/internal.c
@@ -38,6 +38,7 @@
 #include <openssl/des.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
+#include <openssl/sha.h>
 #endif
 
 #include <stddef.h>

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -202,6 +202,7 @@ ykpiv_rc _ykpiv_select_application(ykpiv_state *state, bool scp11);
 size_t _ykpiv_get_length_size(size_t length);
 size_t _ykpiv_set_length(unsigned char *buffer, size_t length);
 size_t _ykpiv_get_length(const unsigned char *buffer, const unsigned char* end, size_t *len);
+ykpiv_rc scp11_open_secure_channel(ykpiv_state* state);
 
 void* _ykpiv_alloc(ykpiv_state *state, size_t size);
 void* _ykpiv_realloc(ykpiv_state *state, void *address, size_t size);

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -192,6 +192,7 @@ typedef union u_APDU APDU;
 
 pkcs5_rc pkcs5_pbkdf2_sha1(const uint8_t* password, const size_t cb_password, const uint8_t* salt, const size_t cb_salt, uint64_t iterations, const uint8_t* key, const size_t cb_key);
 bool   yk_des_is_weak_key(const unsigned char *key, const size_t cb_key);
+unsigned char* hash_sha256(const unsigned char* data, size_t count, unsigned char* md_buf);
 
 prng_rc _ykpiv_prng_generate(unsigned char *buffer, const size_t cb_req);
 ykpiv_rc _ykpiv_begin_transaction(ykpiv_state *state);
@@ -255,7 +256,7 @@ void _ykpiv_debug(const char *file, int line, const char *func, int lvl, const c
 #define DBG3(fmt, ...) _ykpiv_debug(__FILE__, __LINE__, __FUNCTION__, 3, fmt, ##__VA_ARGS__)
 
 #ifdef _WIN32
-#include <windows.h>
+//#include <windows.h>
 #define yc_memzero SecureZeroMemory
 #elif defined(HAVE_EXPLICIT_BZERO)
 #include <strings.h>

--- a/lib/scp11_util.c
+++ b/lib/scp11_util.c
@@ -36,7 +36,7 @@
 #include "../aes_cmac/aes_cmac.h"
 
 #ifdef _WIN32
-//#include <winsock.h>
+#include <winsock.h>
 #else
 #include <arpa/inet.h>
 #endif

--- a/lib/scp11_util.c
+++ b/lib/scp11_util.c
@@ -71,7 +71,7 @@ static ykpiv_rc compute_full_mac(const uint8_t *data, uint32_t data_len,
                               const uint8_t *key, uint32_t key_len,
                               uint8_t *mac) {
 
-  aes_context aes_ctx;
+  aes_context aes_ctx = { 0 };
   int drc = aes_set_key(key, key_len, YKPIV_ALGO_AES128, &aes_ctx);
   if (drc) {
     DBG("%s: aes_set_key: %d", ykpiv_strerror(YKPIV_KEY_ERROR), drc);

--- a/lib/util.c
+++ b/lib/util.c
@@ -31,8 +31,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <time.h>
-#include <openssl/ec.h>
-#include <openssl/evp.h>
  
 #ifdef USE_CERT_COMPRESS
 #include <zlib.h>

--- a/lib/ykpiv.c
+++ b/lib/ykpiv.c
@@ -679,7 +679,7 @@ sc_verify_cleanup:
   return rc;
  }
 
-static ykpiv_rc scp11_open_secure_channel(ykpiv_state *state) {
+ykpiv_rc scp11_open_secure_channel(ykpiv_state *state) {
   ykpiv_rc rc;
 
   //DER encode:
@@ -765,6 +765,8 @@ ykpiv_rc _ykpiv_select_application(ykpiv_state *state, bool scp11) {
 
   ykpiv_rc res = YKPIV_OK;
   if(scp11) {
+    // reset scp11 state if previously negotiated security level
+    yc_memzero(&(state->scp11_state), sizeof(ykpiv_scp11_state));
     res = scp11_open_secure_channel(state);
   } else {
     unsigned char templ[] = {0x00, YKPIV_INS_SELECT_APPLICATION, 0x04, 0x00};
@@ -2815,37 +2817,53 @@ ykpiv_rc ykpiv_auth_deauthenticate(ykpiv_state *state) {
   return res;
 }
 
-/* deauthenticates the user pin and mgm key */
+/* deauthenticates the user pin */
 static ykpiv_rc _ykpiv_auth_deauthenticate(ykpiv_state *state) {
   ykpiv_rc res = YKPIV_OK;
-  unsigned char templ[] = {0x00, YKPIV_INS_SELECT_APPLICATION, 0x04, 0x00};
-  unsigned char data[256] = {0};
+  unsigned char data[256] = { 0 };
   unsigned long recv_len = sizeof(data);
-  const unsigned char *aid;
-  unsigned long aid_len;
   int sw = 0;
 
   if (!state) {
     return YKPIV_ARGUMENT_ERROR;
   }
 
-  // Once mgmt_aid is selected on NEO we can't select piv_aid again... So we use yk_aid.
-  // But... YK 5 below 5.3 doesn't allow access to yk_aid, so still use mgmt_aid on non-NEO devices
+  if (is_version_compatible(state, 5, 4, 3)) {
+    unsigned char templ[] = { 0x00, YKPIV_INS_VERIFY, 0xFF, 0x80 };
 
-  if (state->ver.major < 4 && state->ver.major != 0) {
-    aid = yk_aid;
-    aid_len = sizeof(yk_aid);
-  } else {
-    aid = mgmt_aid;
-    aid_len = sizeof(mgmt_aid);
-  }
+    res = _ykpiv_transfer_data(state, templ, data, 0, data, &recv_len, &sw);
 
-  if ((res = _ykpiv_transfer_data(state, templ, aid, aid_len, data, &recv_len, &sw)) < YKPIV_OK) {
-    return res;
+    if (res < YKPIV_OK) {
+      res = ykpiv_translate_sw_ex(__FUNCTION__, sw);
+      if (res != YKPIV_OK) {
+        DBG("Failed deauthenticating pin");
+      }
+    }
   }
-  res = ykpiv_translate_sw_ex(__FUNCTION__, sw);
-  if (res != YKPIV_OK) {
-    DBG("Failed selecting mgmt/yk application");
+  else {
+    unsigned char templ[] = { 0x00, YKPIV_INS_SELECT_APPLICATION, 0x04, 0x00 };
+    const unsigned char* aid;
+    unsigned long aid_len;
+
+    // Once mgmt_aid is selected on NEO we can't select piv_aid again... So we use yk_aid.
+    // But... YK 5 below 5.3 doesn't allow access to yk_aid, so still use mgmt_aid on non-NEO devices
+
+    if (state->ver.major < 4 && state->ver.major != 0) {
+      aid = yk_aid;
+      aid_len = sizeof(yk_aid);
+    }
+    else {
+      aid = mgmt_aid;
+      aid_len = sizeof(mgmt_aid);
+    }
+
+    if ((res = _ykpiv_transfer_data(state, templ, aid, aid_len, data, &recv_len, &sw)) < YKPIV_OK) {
+      return res;
+    }
+    res = ykpiv_translate_sw_ex(__FUNCTION__, sw);
+    if (res != YKPIV_OK) {
+      DBG("Failed selecting mgmt/yk application");
+    }
   }
 
   return res;

--- a/lib/ykpiv.c
+++ b/lib/ykpiv.c
@@ -719,7 +719,7 @@ ykpiv_rc scp11_open_secure_channel(ykpiv_state *state) {
   }
 
   data_len = sizeof(scp11_keyagreement_template) + 1 + oce_pubkey_len;
-  if (sizeof(data_len) + 5 > YKPIV_OBJ_MAX_SIZE) { // Total APDU length
+  if (data_len + 5 > YKPIV_OBJ_MAX_SIZE) { // Total APDU length
     DBG("Message too long");
     return YKPIV_SIZE_ERROR;
   }
@@ -2236,7 +2236,7 @@ ykpiv_rc ykpiv_verify(ykpiv_state *state, const char *pin, int *tries) {
 }
 
 ykpiv_rc ykpiv_verify_bio(ykpiv_state *state, uint8_t *spin, size_t *p_spin_len, int *tries, bool verify_spin) {
-  return _ykpiv_verify_select(state, spin, p_spin_len, tries, false, true, verify_spin);
+  return _ykpiv_verify_select(state, (char*)spin, p_spin_len, tries, false, true, verify_spin);
 }
 
 ykpiv_rc ykpiv_verify_select(ykpiv_state *state, const char *pin, const size_t pin_len, int *tries, bool force_select) {
@@ -2924,7 +2924,7 @@ ykpiv_rc ykpiv_auth_get_verified(ykpiv_state* state) {
 }
 
 ykpiv_rc ykpiv_auth_verify(ykpiv_state* state, uint8_t* pin, size_t* p_pin_len, int *tries, bool force_select, bool bio, bool verify_spin) {
-  return _ykpiv_verify_select(state, pin, p_pin_len, tries, force_select, bio, verify_spin);
+  return _ykpiv_verify_select(state, (char*)pin, p_pin_len, tries, force_select, bio, verify_spin);
 }
 
 ykpiv_rc ykpiv_global_reset(ykpiv_state *state) {

--- a/lib/ykpiv.c
+++ b/lib/ykpiv.c
@@ -1189,7 +1189,7 @@ ykpiv_rc ykpiv_translate_sw_ex(const char *whence, int sw) {
       return YKPIV_NOT_SUPPORTED;
     case SW_ERR_CONDITIONS_OF_USE:
       DBG("%s: SW_ERR_CONDITIONS_OF_USE", whence);
-      return YKPIV_GENERIC_ERROR;
+      return YKPIV_CONDITION_ERROR;
     case SW_ERR_NO_INPUT_DATA:
       DBG("%s: SW_ERR_NO_INPUT_DATA", whence);
       return YKPIV_ARGUMENT_ERROR;
@@ -2877,7 +2877,7 @@ bool is_version_compatible(ykpiv_state *state, uint8_t major, uint8_t minor, uin
 #endif
 
   return state->ver.major > major ||
-         (state->ver.major == major && state->ver.minor >= minor) ||
+         (state->ver.major == major && state->ver.minor > minor) ||
          (state->ver.major == major && state->ver.minor == minor && state->ver.patch >= patch);
 }
 

--- a/lib/ykpiv.h
+++ b/lib/ykpiv.h
@@ -71,6 +71,7 @@ extern "C"
     YKPIV_RANGE_ERROR = -15, //i.e. value range error
     YKPIV_NOT_SUPPORTED = -16,
     YKPIV_PCSC_SERVICE_ERROR = -17,
+    YKPIV_CONDITION_ERROR = -18,
   } ykpiv_rc;
 
   typedef void* (*ykpiv_pfn_alloc)(void* alloc_data, size_t size);


### PR DESCRIPTION
I have ported the ECDH CNG functions to be Win8 compatible (earlier CNG implementations do not support pseudo-handles).  Also, a lot of MSVC specific warnings have been mitigated in libykpiv for a clean build in the tool and minidriver build.

The scp11_open_channel function has been made internal public to the minidriver, to deterministically establish an scp connection, since it cannot use the standard ykpiv_connect function.

I also found a logic error in the size check for scp11b messages, which has been fixed.