### PR TITLE
Fix const correctness in OpenSSL utils for OpenSSL 4

### DIFF
--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -1905,7 +1905,7 @@ static void print_slot_info(ykpiv_state *state, enum enum_slot slot, const EVP_M
   ykpiv_metadata slot_md = {0};
   X509 *x509 = NULL;
   EVP_PKEY *key = NULL;
-  X509_NAME *subj;
+  const X509_NAME *subj;
   BIO *bio = NULL;
   bool cert_found = false, metadata_found = false;
 

--- a/ykcs11/openssl_utils.c
+++ b/ykcs11/openssl_utils.c
@@ -175,8 +175,8 @@ CK_RV do_sign_empty_cert(const char *cn, ykcs11_pkey_t *pubkey, ykcs11_pkey_t *p
     return CKR_HOST_MEMORY;
   }
   X509_set_version(*cert, 2); // Version 3
-  X509_NAME_add_entry_by_txt(X509_get_issuer_name(*cert), "CN", MBSTRING_ASC, (const unsigned char*)cn, -1, -1, 0);
-  X509_NAME_add_entry_by_txt(X509_get_subject_name(*cert), "CN", MBSTRING_ASC, (const unsigned char*)cn, -1, -1, 0);
+  X509_NAME_add_entry_by_txt((X509_NAME *)X509_get_issuer_name(*cert), "CN", MBSTRING_ASC, (const unsigned char*)cn, -1, -1, 0);
+  X509_NAME_add_entry_by_txt((X509_NAME *)X509_get_subject_name(*cert), "CN", MBSTRING_ASC, (const unsigned char*)cn, -1, -1, 0);
   ASN1_INTEGER_set(X509_get_serialNumber(*cert), 0);
   X509_gmtime_adj(X509_get_notBefore(*cert), 0);
   X509_gmtime_adj(X509_get_notAfter(*cert), 0);
@@ -272,7 +272,7 @@ CK_RV do_get_raw_cert(ykcs11_x509_t *cert, CK_BYTE_PTR out, CK_ULONG_PTR out_len
   return CKR_OK;
 }
 
-CK_RV do_get_raw_name(ykcs11_x509_name_t *name, CK_BYTE_PTR out, CK_ULONG_PTR out_len) {
+CK_RV do_get_raw_name(const ykcs11_x509_name_t *name, CK_BYTE_PTR out, CK_ULONG_PTR out_len) {
 
   CK_BYTE_PTR p;
   int         len;
@@ -355,11 +355,11 @@ CK_RV do_parse_attestation(ykcs11_x509_t *cert, CK_BYTE_PTR pin_policy, CK_BYTE_
   if (pos < 0)
     return CKR_FUNCTION_FAILED;
 
-  X509_EXTENSION *ext = X509_get_ext(cert, pos);
+  X509_EXTENSION *ext = (X509_EXTENSION *)X509_get_ext(cert, pos);
   if (ext == NULL)
     return CKR_FUNCTION_FAILED;
 
-  ASN1_OCTET_STRING *oct = X509_EXTENSION_get_data(ext);
+  ASN1_OCTET_STRING *oct = (ASN1_OCTET_STRING *)X509_EXTENSION_get_data(ext);
   if (oct == NULL)
     return CKR_FUNCTION_FAILED;
 

--- a/ykcs11/openssl_utils.h
+++ b/ykcs11/openssl_utils.h
@@ -46,7 +46,7 @@ CK_RV do_create_empty_cert(CK_BYTE_PTR in, CK_ULONG in_len, CK_ULONG algorithm,
                            const char *cn, CK_BYTE_PTR out, CK_ULONG_PTR out_len);
 CK_RV do_check_cert(CK_BYTE_PTR in, CK_ULONG in_len, CK_ULONG_PTR cert_len);
 CK_RV do_get_raw_cert(ykcs11_x509_t *cert, CK_BYTE_PTR out, CK_ULONG_PTR out_len);
-CK_RV do_get_raw_name(ykcs11_x509_name_t *name, CK_BYTE_PTR out, CK_ULONG_PTR out_len);
+CK_RV do_get_raw_name(const ykcs11_x509_name_t *name, CK_BYTE_PTR out, CK_ULONG_PTR out_len);
 CK_RV do_get_raw_integer(ykcs11_asn1_integer_t *serial, CK_BYTE_PTR out, CK_ULONG_PTR out_len);
 CK_RV do_delete_cert(ykcs11_x509_t **cert);
 

--- a/ykcs11/tests/ykcs11_tests_util.c
+++ b/ykcs11/tests/ykcs11_tests_util.c
@@ -334,8 +334,8 @@ EVP_PKEY* import_edkey(CK_FUNCTION_LIST_3_0_PTR funcs, CK_SESSION_HANDLE session
 
   X509 *cert = X509_new();
   X509_set_version(cert, 2); // Version 3
-  X509_NAME_add_entry_by_txt(X509_get_issuer_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Issuer", -1, -1, 0);
-  X509_NAME_add_entry_by_txt(X509_get_subject_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Subject", -1, -1, 0);
+  X509_NAME_add_entry_by_txt((X509_NAME *)X509_get_issuer_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Issuer", -1, -1, 0);
+  X509_NAME_add_entry_by_txt((X509_NAME *)X509_get_subject_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Subject", -1, -1, 0);
   ASN1_INTEGER_set(X509_get_serialNumber(cert), 0);
   X509_gmtime_adj(X509_get_notBefore(cert), 0);
   X509_gmtime_adj(X509_get_notAfter(cert), 0);
@@ -413,8 +413,8 @@ void import_x25519key(CK_FUNCTION_LIST_3_0_PTR funcs, CK_SESSION_HANDLE session,
 
   X509 *cert = X509_new();
   X509_set_version(cert, 2); // Version 3
-  X509_NAME_add_entry_by_txt(X509_get_issuer_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Issuer", -1, -1, 0);
-  X509_NAME_add_entry_by_txt(X509_get_subject_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Subject", -1, -1, 0);
+  X509_NAME_add_entry_by_txt((X509_NAME *)X509_get_issuer_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Issuer", -1, -1, 0);
+  X509_NAME_add_entry_by_txt((X509_NAME *)X509_get_subject_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Subject", -1, -1, 0);
   ASN1_INTEGER_set(X509_get_serialNumber(cert), 0);
   X509_gmtime_adj(X509_get_notBefore(cert), 0);
   X509_gmtime_adj(X509_get_notAfter(cert), 0);
@@ -496,8 +496,8 @@ EC_KEY* import_ec_key(CK_FUNCTION_LIST_3_0_PTR funcs, CK_SESSION_HANDLE session,
     exit(EXIT_FAILURE);
 
   X509_set_version(cert, 2); // Version 3
-  X509_NAME_add_entry_by_txt(X509_get_issuer_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Issuer", -1, -1, 0);
-  X509_NAME_add_entry_by_txt(X509_get_subject_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Subject", -1, -1, 0);
+  X509_NAME_add_entry_by_txt((X509_NAME *)X509_get_issuer_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Issuer", -1, -1, 0);
+  X509_NAME_add_entry_by_txt((X509_NAME *)X509_get_subject_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Subject", -1, -1, 0);
   ASN1_INTEGER_set(X509_get_serialNumber(cert), 0);
   X509_gmtime_adj(X509_get_notBefore(cert), 0);
   X509_gmtime_adj(X509_get_notAfter(cert), 0);
@@ -664,8 +664,8 @@ void import_rsa_key(CK_FUNCTION_LIST_3_0_PTR funcs, CK_SESSION_HANDLE session, i
     exit(EXIT_FAILURE);
 
   X509_set_version(cert, 2); // Version 3
-  X509_NAME_add_entry_by_txt(X509_get_issuer_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Issuer", -1, -1, 0);
-  X509_NAME_add_entry_by_txt(X509_get_subject_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Subject", -1, -1, 0);
+  X509_NAME_add_entry_by_txt((X509_NAME *)X509_get_issuer_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Issuer", -1, -1, 0);
+  X509_NAME_add_entry_by_txt((X509_NAME *)X509_get_subject_name(cert), "CN", MBSTRING_ASC, (unsigned char*)"Test Subject", -1, -1, 0);
   ASN1_INTEGER_set(X509_get_serialNumber(cert), 0);
   X509_gmtime_adj(X509_get_notBefore(cert), 0);
   X509_gmtime_adj(X509_get_notAfter(cert), 0);


### PR DESCRIPTION
Updated function signatures, variable declarations, and return casts to use the appropriate const qualifiers. This resolves compiler warnings and ensures compatibility with versions of OpenSSL that enforce stricter const-correctness in their APIs.