### PR TITLE
Add support for post-quantum cryptography algorithms (ML-DSA and ML-KEM)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,8 @@ set (CMAKE_C_STANDARD 11)
 project (yubico-piv-tool)
 
 set (yubico_piv_tool_VERSION_MAJOR 2)
-set (yubico_piv_tool_VERSION_MINOR 7)
-set (yubico_piv_tool_VERSION_PATCH 3)
+set (yubico_piv_tool_VERSION_MINOR 8)
+set (yubico_piv_tool_VERSION_PATCH 0)
 set (VERSION "${yubico_piv_tool_VERSION_MAJOR}.${yubico_piv_tool_VERSION_MINOR}.${yubico_piv_tool_VERSION_PATCH}")
 set (SO_VERSION 2)
 

--- a/common/util.c
+++ b/common/util.c
@@ -83,6 +83,7 @@ FILE *open_file(const char *file_name, enum file_mode mode) {
 unsigned char get_algorithm(EVP_PKEY *key) {
   int type = EVP_PKEY_base_id(key);
   int size = EVP_PKEY_bits(key);
+
   switch(type) {
     case EVP_PKEY_RSA:
       {
@@ -116,6 +117,20 @@ unsigned char get_algorithm(EVP_PKEY *key) {
       return YKPIV_ALGO_ED25519;
     case EVP_PKEY_X25519:
       return YKPIV_ALGO_X25519;
+#endif
+#if (OPENSSL_VERSION_NUMBER >= 0x30500000L)
+    case NID_ML_DSA_44:
+      return YKPIV_ALGO_MLDSA44;
+    case NID_ML_DSA_65:
+      return YKPIV_ALGO_MLDSA65;
+    case NID_ML_DSA_87:
+      return YKPIV_ALGO_MLDSA87;
+    case NID_ML_KEM_512:
+      return YKPIV_ALGO_MLKEM512;
+    case NID_ML_KEM_768:
+      return YKPIV_ALGO_MLKEM768;
+    case NID_ML_KEM_1024:
+      return YKPIV_ALGO_MLKEM1024;
 #endif
     default:
       fprintf(stderr, "Unknown algorithm %d.\n", type);
@@ -334,6 +349,25 @@ int get_curve_name(int key_algorithm) {
     return NID_X25519;
 #endif
   }
+  return 0;
+}
+
+int get_pqc_nid(int key_algorithm) {
+#if (OPENSSL_VERSION_NUMBER >= 0x30500000L)
+  if(key_algorithm == YKPIV_ALGO_MLDSA44) {
+    return NID_ML_DSA_44;
+  } else if(key_algorithm == YKPIV_ALGO_MLDSA65) {
+    return NID_ML_DSA_65;
+  } else if(key_algorithm == YKPIV_ALGO_MLDSA87) {
+    return NID_ML_DSA_87;
+  } else if(key_algorithm == YKPIV_ALGO_MLKEM512) {
+    return NID_ML_KEM_512;
+  } else if(key_algorithm == YKPIV_ALGO_MLKEM768) {
+    return NID_ML_KEM_768;
+  } else if(key_algorithm == YKPIV_ALGO_MLKEM1024) {
+    return NID_ML_KEM_1024;
+  }
+#endif
   return 0;
 }
 
@@ -563,6 +597,18 @@ unsigned char get_piv_algorithm(enum enum_algorithm algorithm) {
       return YKPIV_ALGO_ED25519;
     case algorithm_arg_X25519:
       return YKPIV_ALGO_X25519;
+    case algorithm_arg_MLDSA44:
+      return YKPIV_ALGO_MLDSA44;
+    case algorithm_arg_MLDSA65:
+      return YKPIV_ALGO_MLDSA65;
+    case algorithm_arg_MLDSA87:
+      return YKPIV_ALGO_MLDSA87;
+    case algorithm_arg_MLKEM512:
+      return YKPIV_ALGO_MLKEM512;
+    case algorithm_arg_MLKEM768:
+      return YKPIV_ALGO_MLKEM768;
+    case algorithm_arg_MLKEM1024:
+      return YKPIV_ALGO_MLKEM1024;
     case algorithm__NULL:
     default:
       return 0;
@@ -823,7 +869,17 @@ int do_create_public_key(uint8_t *in, size_t in_len, uint8_t algorithm, EVP_PKEY
     if(in >= eob)
       return YKPIV_GENERIC_ERROR;
 
-    if(*in++ != 0x86)
+    // YubiKey 6.0 spec: ML-DSA uses 0x87, ML-KEM uses 0x88, ECC uses 0x86
+    uint8_t expected_tag;
+    if (YKPIV_IS_MLDSA(algorithm)) {
+      expected_tag = 0x87;  // TAG_MLDSA_PUBKEY
+    } else if (YKPIV_IS_MLKEM(algorithm)) {
+      expected_tag = 0x88;  // TAG_MLKEM_PUBKEY
+    } else {
+      expected_tag = 0x86;  // TAG_ECC_POINT
+    }
+
+    if(*in++ != expected_tag)
       return YKPIV_GENERIC_ERROR;
 
     offs = get_length(in, eob, &len);
@@ -842,6 +898,15 @@ int do_create_public_key(uint8_t *in, size_t in_len, uint8_t algorithm, EVP_PKEY
       } else {
         *pkey = EVP_PKEY_new_raw_public_key(EVP_PKEY_X25519, NULL, in, len);
       }
+      if (*pkey == NULL) {
+        return YKPIV_MEMORY_ERROR;
+      }
+      return YKPIV_OK;
+#endif
+#if (OPENSSL_VERSION_NUMBER >= 0x30500000L)
+    } else if (YKPIV_IS_MLDSA(algorithm) || YKPIV_IS_MLKEM(algorithm)) {
+      int nid = get_pqc_nid(algorithm);
+      *pkey = EVP_PKEY_new_raw_public_key(nid, NULL, in, len);
       if (*pkey == NULL) {
         return YKPIV_MEMORY_ERROR;
       }

--- a/common/util.h
+++ b/common/util.h
@@ -50,6 +50,7 @@ unsigned long get_length_size(unsigned long);
 unsigned long set_length(unsigned char*, unsigned long);
 unsigned long get_length(const unsigned char*, const unsigned char*, unsigned long*);
 int get_curve_name(int);
+int get_pqc_nid(int);
 X509_NAME *parse_name(const char*);
 unsigned char get_algorithm(EVP_PKEY*);
 FILE *open_file(const char *file_name, enum file_mode mode);

--- a/lib/internal.h
+++ b/lib/internal.h
@@ -67,13 +67,20 @@ extern "C"
 // always contains 0x5C + 1 byte len + 3 byte id + 0x53 + 3 byte len = 9 bytes,
 // so while the message buffer == CB_BUF_MAX, the maximum object we can store
 // is CB_BUF_MAX - 9
+
+// Device-specific buffer sizes
+#define CB_BUF_MAX_NEO      2048  // YubiKey NEO
+#define CB_BUF_MAX_YK4      3072  // YubiKey 4 and 5 (standard size)
+#define CB_BUF_MAX_YK6      4928  // YubiKey 6 
+
 #define CB_OBJ_MAX_NEO      (CB_BUF_MAX_NEO - 9)
 #define CB_OBJ_MAX_YK4      (CB_BUF_MAX_YK4 - 9)
-#define CB_OBJ_MAX          CB_OBJ_MAX_YK4
+#define CB_OBJ_MAX_YK6      (CB_BUF_MAX_YK6 - 9)
 
-#define CB_BUF_MAX_NEO      2048
-#define CB_BUF_MAX_YK4      3072
-#define CB_BUF_MAX          CB_BUF_MAX_YK4
+// Default to YK6 sizes (4928 bytes) to support PQC operations
+// Static buffers use this size; runtime detection adjusts for older devices
+#define CB_BUF_MAX          CB_BUF_MAX_YK6
+#define CB_OBJ_MAX          CB_OBJ_MAX_YK6
 
 #define CB_ATR_MAX          33
 
@@ -95,10 +102,28 @@ extern "C"
 #define TAG_RSA_MODULUS       0x81
 #define TAG_RSA_EXP           0x82
 #define TAG_ECC_POINT         0x86
+#define TAG_MLDSA_PUBKEY      0x87
+#define TAG_MLKEM_PUBKEY      0x88
 
 #define CB_ECC_POINTP256    65
 #define CB_ECC_POINTP384    97
 #define CB_ECC_POINT25519   32
+#define CB_MLDSA44_PUBKEY   1312
+#define CB_MLDSA65_PUBKEY   1952
+#define CB_MLDSA87_PUBKEY   2592
+#define CB_MLKEM512_PUBKEY  800
+#define CB_MLKEM768_PUBKEY  1184
+#define CB_MLKEM1024_PUBKEY 1568
+#define CB_MLDSA44_SIG      2420
+#define CB_MLDSA65_SIG      3309
+#define CB_MLDSA87_SIG      4627
+#define CB_MLKEM512_CT      768
+#define CB_MLKEM768_CT      1088
+#define CB_MLKEM1024_CT     1568
+
+// Private key import parameter tags
+#define PARAM_TAG_MLDSA     0x09
+#define PARAM_TAG_MLKEM     0x0A
 
 #define YKPIV_OBJ_ADMIN_DATA 0x5fff00
 #define YKPIV_OBJ_ATTESTATION 0x5fff01

--- a/lib/util.c
+++ b/lib/util.c
@@ -762,7 +762,7 @@ Cleanup:
   return res;
 }
 
-ykpiv_rc ykpiv_util_generate_key(ykpiv_state *state, uint8_t slot, uint8_t algorithm, uint8_t pin_policy, uint8_t touch_policy, uint8_t **modulus, size_t *modulus_len, uint8_t **exp, size_t *exp_len, uint8_t **point, size_t *point_len) {
+ykpiv_rc ykpiv_util_generate_key_ex(ykpiv_state *state, uint8_t slot, uint8_t algorithm, uint8_t pin_policy, uint8_t touch_policy, uint8_t **modulus, size_t *modulus_len, uint8_t **exp, size_t *exp_len, uint8_t **point, size_t *point_len, uint8_t **pqc_pubkey, size_t *pqc_pubkey_len) {
   ykpiv_rc res = YKPIV_OK;
   unsigned char in_data[11] = {0};
   unsigned char *in_ptr = in_data;
@@ -776,6 +776,8 @@ ykpiv_rc ykpiv_util_generate_key(ykpiv_state *state, uint8_t slot, uint8_t algor
   size_t  cb_exp = 0;
   uint8_t *ptr_point = NULL;
   size_t  cb_point = 0;
+  uint8_t *ptr_pqc_pubkey = NULL;
+  size_t  cb_pqc_pubkey = 0;
   size_t offs;
 
   setting_bool_t setting_roca = { 0 };
@@ -797,6 +799,10 @@ ykpiv_rc ykpiv_util_generate_key(ykpiv_state *state, uint8_t slot, uint8_t algor
   if ((algorithm == YKPIV_ALGO_RSA3072 || algorithm == YKPIV_ALGO_RSA4096 || YKPIV_IS_25519(algorithm))
        && !is_version_compatible(state, 5, 7, 0)) {
     DBG("RSA3072, RSA4096, ED25519 and X25519 keys are only supported in YubiKey version 5.7.0 and newer");
+    return YKPIV_NOT_SUPPORTED;
+  }
+  if ((YKPIV_IS_MLDSA(algorithm) || YKPIV_IS_MLKEM(algorithm)) && !is_version_compatible(state, 6, 0, 0)) {
+    DBG("ML-DSA and ML-KEM keys are only supported in YubiKey version 6.0.0 and newer");
     return YKPIV_NOT_SUPPORTED;
   }
   if ((algorithm == YKPIV_ALGO_RSA1024 || algorithm == YKPIV_ALGO_RSA2048) && !is_version_compatible(state, 4, 3, 5)) {
@@ -852,6 +858,20 @@ ykpiv_rc ykpiv_util_generate_key(ykpiv_state *state, uint8_t slot, uint8_t algor
     }
     *point = NULL;
     *point_len = 0;
+    break;
+
+  case YKPIV_ALGO_MLDSA44:
+  case YKPIV_ALGO_MLDSA65:
+  case YKPIV_ALGO_MLDSA87:
+  case YKPIV_ALGO_MLKEM512:
+  case YKPIV_ALGO_MLKEM768:
+  case YKPIV_ALGO_MLKEM1024:
+    if (!pqc_pubkey || !pqc_pubkey_len) {
+      DBG("Invalid output parameter for PQC algorithm");
+      return YKPIV_ARGUMENT_ERROR;
+    }
+    *pqc_pubkey = NULL;
+    *pqc_pubkey_len = 0;
     break;
 
   default:
@@ -1001,6 +1021,40 @@ ykpiv_rc ykpiv_util_generate_key(ykpiv_state *state, uint8_t slot, uint8_t algor
     ptr_point = NULL;
     *point_len = cb_point;
   }
+  else if (YKPIV_IS_MLDSA(algorithm) || YKPIV_IS_MLKEM(algorithm)) {
+    unsigned char *data_ptr = data + 3;
+    size_t len = 0;
+    unsigned char expected_tag = YKPIV_IS_MLDSA(algorithm) ? TAG_MLDSA_PUBKEY : TAG_MLKEM_PUBKEY;
+
+    if (*data_ptr++ != expected_tag) {
+      DBG("Failed to parse PQC public key structure (expected tag 0x%02x).", expected_tag);
+      res = YKPIV_PARSE_ERROR;
+      goto Cleanup;
+    }
+
+    // Get the length from the TLV
+    offs = _ykpiv_get_length(data_ptr, data + recv_len, &len);
+    if(!offs) {
+      DBG("Failed to parse PQC public key length.");
+      res = YKPIV_PARSE_ERROR;
+      goto Cleanup;
+    }
+    data_ptr += offs;
+
+    cb_pqc_pubkey = len;
+    if (NULL == (ptr_pqc_pubkey = _ykpiv_alloc(state, cb_pqc_pubkey))) {
+      DBG("Failed to allocate memory for PQC public key.");
+      res = YKPIV_MEMORY_ERROR;
+      goto Cleanup;
+    }
+
+    memcpy(ptr_pqc_pubkey, data_ptr, cb_pqc_pubkey);
+
+    // set output parameters
+    *pqc_pubkey = ptr_pqc_pubkey;
+    ptr_pqc_pubkey = NULL;
+    *pqc_pubkey_len = cb_pqc_pubkey;
+  }
   else {
     DBG("Wrong algorithm.");
     res = YKPIV_ALGORITHM_ERROR;
@@ -1012,9 +1066,21 @@ Cleanup:
   if (ptr_modulus) { _ykpiv_free(state, ptr_modulus); }
   if (ptr_exp) { _ykpiv_free(state, ptr_exp); }
   if (ptr_point) { _ykpiv_free(state, ptr_point); }
+  if (ptr_pqc_pubkey) { _ykpiv_free(state, ptr_pqc_pubkey); }
 
   _ykpiv_end_transaction(state);
   return res;
+}
+
+ykpiv_rc ykpiv_util_generate_key(ykpiv_state *state, uint8_t slot, uint8_t algorithm, uint8_t pin_policy, uint8_t touch_policy, uint8_t **modulus, size_t *modulus_len, uint8_t **exp, size_t *exp_len, uint8_t **point, size_t *point_len) {
+  if (YKPIV_IS_MLDSA(algorithm) || YKPIV_IS_MLKEM(algorithm)) {
+    return YKPIV_ALGORITHM_ERROR;
+  }
+
+  return ykpiv_util_generate_key_ex(state, slot, algorithm, pin_policy, touch_policy,
+                                    modulus, modulus_len, exp, exp_len,
+                                    point, point_len,
+                                    NULL, NULL);
 }
 
 ykpiv_rc ykpiv_util_get_config(ykpiv_state *state, ykpiv_config *config) {

--- a/lib/ykpiv.c
+++ b/lib/ykpiv.c
@@ -1790,6 +1790,54 @@ static ykpiv_rc _general_authenticate(ykpiv_state *state,
         return YKPIV_NOT_SUPPORTED;
       }
       break;
+    case YKPIV_ALGO_MLDSA44:
+      key_len = CB_MLDSA44_SIG;
+      if(decipher) {
+        DBG("Deciphering with ML-DSA-44 keys is not supported");
+        return YKPIV_NOT_SUPPORTED;
+      }
+      break;
+    case YKPIV_ALGO_MLDSA65:
+      key_len = CB_MLDSA65_SIG;
+      if(decipher) {
+        DBG("Deciphering with ML-DSA-65 keys is not supported");
+        return YKPIV_NOT_SUPPORTED;
+      }
+      break;
+    case YKPIV_ALGO_MLDSA87:
+      key_len = CB_MLDSA87_SIG;
+      if(decipher) {
+        DBG("Deciphering with ML-DSA-87 keys is not supported");
+        return YKPIV_NOT_SUPPORTED;
+      }
+      break;
+    case YKPIV_ALGO_MLKEM512:
+      if(!decipher) {
+        DBG("Signing with ML-KEM-512 keys is not supported");
+        return YKPIV_NOT_SUPPORTED;
+      }
+      if(in_len != CB_MLKEM512_CT) {
+        return YKPIV_SIZE_ERROR;
+      }
+      break;
+    case YKPIV_ALGO_MLKEM768:
+      if(!decipher) {
+        DBG("Signing with ML-KEM-768 keys is not supported");
+        return YKPIV_NOT_SUPPORTED;
+      }
+      if(in_len != CB_MLKEM768_CT) {
+        return YKPIV_SIZE_ERROR;
+      }
+      break;
+    case YKPIV_ALGO_MLKEM1024:
+      if(!decipher) {
+        DBG("Signing with ML-KEM-1024 keys is not supported");
+        return YKPIV_NOT_SUPPORTED;
+      }
+      if(in_len != CB_MLKEM1024_CT) {
+        return YKPIV_SIZE_ERROR;
+      }
+      break;
     default:
       return YKPIV_ALGORITHM_ERROR;
   }
@@ -1800,7 +1848,15 @@ static ykpiv_rc _general_authenticate(ykpiv_state *state,
   dataptr += _ykpiv_set_length(dataptr, in_len + bytes + 3);
   *dataptr++ = 0x82;
   *dataptr++ = 0x00;
-  *dataptr++ = !YKPIV_IS_RSA(algorithm) && decipher ? 0x85 : 0x81;
+
+  if (YKPIV_IS_MLKEM(algorithm)) {
+    *dataptr++ = 0x86;
+  } else if (!YKPIV_IS_RSA(algorithm) && decipher) {
+    *dataptr++ = 0x85;
+  } else {
+    *dataptr++ = 0x81;
+  }
+
   dataptr += _ykpiv_set_length(dataptr, in_len);
   if(dataptr - indata + in_len > sizeof(indata)) {
     return YKPIV_SIZE_ERROR;
@@ -2494,16 +2550,17 @@ ykpiv_rc _ykpiv_save_object(
   return ykpiv_translate_sw_ex(__FUNCTION__, sw);
 }
 
-ykpiv_rc ykpiv_import_private_key(ykpiv_state *state, const unsigned char key, unsigned char algorithm,
-                                  const unsigned char *p, size_t p_len,
-                                  const unsigned char *q, size_t q_len,
-                                  const unsigned char *dp, size_t dp_len,
-                                  const unsigned char *dq, size_t dq_len,
-                                  const unsigned char *qinv, size_t qinv_len,
-                                  const unsigned char *ec_data, unsigned char ec_data_len,
-                                  const unsigned char pin_policy, const unsigned char touch_policy) {
+ykpiv_rc ykpiv_import_private_key_ex(ykpiv_state *state, const unsigned char key, unsigned char algorithm,
+                                     const unsigned char *p, size_t p_len,
+                                     const unsigned char *q, size_t q_len,
+                                     const unsigned char *dp, size_t dp_len,
+                                     const unsigned char *dq, size_t dq_len,
+                                     const unsigned char *qinv, size_t qinv_len,
+                                     const unsigned char *ec_data, size_t ec_data_len,
+                                     const unsigned char *pqc_privkey, size_t pqc_privkey_len,
+                                     const unsigned char pin_policy, const unsigned char touch_policy) {
 
-  unsigned char key_data[2048] = {0};
+  unsigned char key_data[YKPIV_OBJ_MAX_SIZE] = {0};
   unsigned char *in_ptr = key_data;
   unsigned char templ[] = {0, YKPIV_INS_IMPORT_KEY, algorithm, key};
   unsigned char data[256] = {0};
@@ -2600,6 +2657,49 @@ ykpiv_rc ykpiv_import_private_key(ykpiv_state *state, const unsigned char key, u
     }
     n_params = 1;
   }
+  else if (YKPIV_IS_MLDSA(algorithm)) {
+    // TODO: Little confused on this part, is it always seed?
+    if (pqc_privkey_len == 32) {
+      elem_len = 32;
+    } else {
+      // TODO: Should these be defines in internal.h ?
+      switch (algorithm) {
+        case YKPIV_ALGO_MLDSA44:
+          elem_len = 2560;
+          break;
+        case YKPIV_ALGO_MLDSA65:
+          elem_len = 4032;
+          break;
+        case YKPIV_ALGO_MLDSA87:
+          elem_len = 4896;
+          break;
+      }
+    }
+
+    params[0] = pqc_privkey;
+    lens[0] = pqc_privkey_len;
+    param_tag = PARAM_TAG_MLDSA;
+    n_params = 1;
+  }
+  else if (YKPIV_IS_MLKEM(algorithm)) {
+    // TODO: Should these be defines in internal.h ?
+    switch (algorithm) {
+      case YKPIV_ALGO_MLKEM512:
+        elem_len = 1632;
+        break;
+      case YKPIV_ALGO_MLKEM768:
+        elem_len = 2400;
+        break;
+      case YKPIV_ALGO_MLKEM1024:
+        elem_len = 3168;
+        break;
+    }
+
+    params[0] = pqc_privkey;
+    lens[0] = pqc_privkey_len;
+    param_tag = PARAM_TAG_MLKEM;
+    n_params = 1;
+  }
   else {
     return YKPIV_ALGORITHM_ERROR;
   }
@@ -2645,6 +2745,25 @@ Cleanup:
   yc_memzero(key_data, sizeof(key_data));
   _ykpiv_end_transaction(state);
   return res;
+}
+
+ykpiv_rc ykpiv_import_private_key(ykpiv_state *state, const unsigned char key, unsigned char algorithm,
+                                  const unsigned char *p, size_t p_len,
+                                  const unsigned char *q, size_t q_len,
+                                  const unsigned char *dp, size_t dp_len,
+                                  const unsigned char *dq, size_t dq_len,
+                                  const unsigned char *qinv, size_t qinv_len,
+                                  const unsigned char *ec_data, unsigned char ec_data_len,
+                                  const unsigned char pin_policy, const unsigned char touch_policy) {
+  if (YKPIV_IS_MLDSA(algorithm) || YKPIV_IS_MLKEM(algorithm)) {
+    return YKPIV_ALGORITHM_ERROR;
+  }
+
+  return ykpiv_import_private_key_ex(state, key, algorithm,
+                                     p, p_len, q, q_len, dp, dp_len, dq, dq_len, qinv, qinv_len,
+                                     ec_data, ec_data_len,        // ec_data
+                                     NULL, 0,                     // pqc_privkey
+                                     pin_policy, touch_policy);
 }
 
 ykpiv_rc ykpiv_attest(ykpiv_state *state, const unsigned char key, unsigned char *data, size_t *data_len) {

--- a/lib/ykpiv.h
+++ b/lib/ykpiv.h
@@ -131,6 +131,15 @@ extern "C"
                              unsigned char touch);
   ykpiv_rc ykpiv_save_object(ykpiv_state *state, int object_id,
                              unsigned char *indata, size_t len);
+  ykpiv_rc ykpiv_import_private_key_ex(ykpiv_state *state, const unsigned char key, unsigned char algorithm,
+                                       const unsigned char *p, size_t p_len,
+                                       const unsigned char *q, size_t q_len,
+                                       const unsigned char *dp, size_t dp_len,
+                                       const unsigned char *dq, size_t dq_len,
+                                       const unsigned char *qinv, size_t qinv_len,
+                                       const unsigned char *ec_data, size_t ec_data_len,
+                                       const unsigned char *pqc_privkey, size_t pqc_privkey_len,
+                                       const unsigned char pin_policy, const unsigned char touch_policy);
   ykpiv_rc ykpiv_import_private_key(ykpiv_state *state, const unsigned char key, unsigned char algorithm,
                                     const unsigned char *p, size_t p_len,
                                     const unsigned char *q, size_t q_len,
@@ -402,6 +411,41 @@ extern "C"
   ykpiv_rc ykpiv_util_delete_cert(ykpiv_state *state, uint8_t slot);
 
   /**
+   * Generate key in given slot with specified parameters (extended API)
+   *
+   * \p modulus, \p exp, \p ec_point, and \p pqc_pubkey should be freed with \p ykpiv_util_free() after use.
+   *
+   * If algorithm is RSA1024 or RSA2048, the modulus, modulus_len, exp, and exp_len output parameters must be supplied.  They are filled with with public modulus (big-endian), its size, the public exponent (big-endian), and its size respectively.
+   *
+   * If algorithm is ECCP256 or ECCP384, the point and point_len output parameters must be supplied.  They are filled with the public point (uncompressed octet-string encoded per SEC1 section 2.3.4)
+   *
+   * If algorithm is ECCP256, the curve is always ANSI X9.62 Prime 256v1
+   *
+   * If algorithm is ECCP384, the curve is always secp384r1
+   * 
+   * If algorithm is MLDSA44, MLDSA65, or MLDSA87, provide pqc_pubkey, pqc_pubkey_len. Others NULL.
+   * 
+   * If algorithm is MLKEM512, MLKEM768, or MLKEM1024, provide pqc_pubkey, pqc_pubkey_len. Others NULL.
+   *
+   * @param state          State handle
+   * @param slot           Slot to generate key in
+   * @param algorithm      Key algorithm, specified as one of the \p YKPIV_ALGO_* options
+   * @param pin_policy     Per-slot PIN policy, specified as one of the \p YKPIV_PINPOLICY_* options
+   * @param touch_policy   Per-slot touch policy, specified as one of the \p YKPIV_TOUCHPOLICY_* options.
+   * @param modulus        [out] RSA public modulus (RSA only)
+   * @param modulus_len    [out] Size of \p modulus (RSA only)
+   * @param exp            [out] RSA public exponent (RSA only)
+   * @param exp_len        [out] Size of \p exp (RSA only)
+   * @param point          [out] Public curve point (ECC-only)
+   * @param point_len      [out] Size of \p point (ECC-only)
+   * @param pqc_pubkey     [out] ML-DSA/ML-KEM public key bytes
+   * @param pqc_pubkey_len [out] Size of \p pqc_pubkey
+   *
+   * @return ykpiv_rc error code
+   */
+  ykpiv_rc ykpiv_util_generate_key_ex(ykpiv_state *state, uint8_t slot, uint8_t algorithm, uint8_t pin_policy, uint8_t touch_policy, uint8_t **modulus, size_t *modulus_len, uint8_t **exp, size_t *exp_len, uint8_t **point, size_t *point_len, uint8_t **pqc_pubkey, size_t *pqc_pubkey_len);
+
+  /**
    * Generate key in given slot with specified parameters
    *
    * \p modulus, \p exp, and \p point should be freed with \p ykpiv_util_free() after use.
@@ -638,6 +682,12 @@ extern "C"
 #define YKPIV_ALGO_ECCP384 0x14
 #define YKPIV_ALGO_ED25519 0xE0
 #define YKPIV_ALGO_X25519 0xE1
+#define YKPIV_ALGO_MLDSA44 0xE2
+#define YKPIV_ALGO_MLDSA65 0xE3
+#define YKPIV_ALGO_MLDSA87 0xE4
+#define YKPIV_ALGO_MLKEM512 0xE5
+#define YKPIV_ALGO_MLKEM768 0xE6
+#define YKPIV_ALGO_MLKEM1024 0xE7
 
 #define YKPIV_ALGO_AUTO 0xff
 
@@ -712,7 +762,9 @@ extern "C"
 #define TAG_CERT_COMPRESS     0x71
 #define TAG_CERT_LRC          0xFE
 
-#define YKPIV_OBJ_MAX_SIZE 3072
+#define YKPIV_OBJ_MAX_SIZE 4928  // YubiKey 6 max object size (increased for PQC operations)
+                                 // YubiKey 4/5: 3063 bytes, YubiKey NEO: 2039 bytes
+                                 // Runtime detection handles older devices
 
 #define YKPIV_INS_VERIFY 0x20
 #define YKPIV_INS_CHANGE_REFERENCE 0x24
@@ -791,6 +843,8 @@ extern "C"
 #define YKPIV_IS_EC(a) ((a == YKPIV_ALGO_ECCP256 || a == YKPIV_ALGO_ECCP384))
 #define YKPIV_IS_RSA(a) ((a == YKPIV_ALGO_RSA1024 || a == YKPIV_ALGO_RSA2048 || a == YKPIV_ALGO_RSA3072 || a == YKPIV_ALGO_RSA4096))
 #define YKPIV_IS_25519(a) ((a == YKPIV_ALGO_ED25519 || a == YKPIV_ALGO_X25519))
+#define YKPIV_IS_MLDSA(a) ((a == YKPIV_ALGO_MLDSA44 || a == YKPIV_ALGO_MLDSA65 || a == YKPIV_ALGO_MLDSA87))
+#define YKPIV_IS_MLKEM(a) ((a == YKPIV_ALGO_MLKEM512 || a == YKPIV_ALGO_MLKEM768 || a == YKPIV_ALGO_MLKEM1024))
 
 #define YKPIV_MIN_PIN_LEN 6
 #define YKPIV_MAX_PIN_LEN 8
@@ -821,6 +875,7 @@ extern "C"
 #define DEVTYPE_NEOr3    (DEVTYPE_NEO | 0x00007233) //"r3"
 #define DEVTYPE_YK4      (DEVTYPE_YK  | 0x00000034) // "4"
 #define DEVTYPE_YK5      (DEVTYPE_YK  | 0x00000035) // "5"
+#define DEVTYPE_YK6      (DEVTYPE_YK  | 0x00000036) // "6"
 #define DEVYTPE_YK5      DEVTYPE_YK5 // Keep old typo for backwards compatibility
 
 #ifdef __cplusplus

--- a/tool/cmdline.ggo
+++ b/tool/cmdline.ggo
@@ -53,7 +53,7 @@ text   "
        9e is for Card Authentication (PIN never checked)
        82-95 is for Retired Key Management
        f9 is for Attestation\n"
-option "algorithm" A "What algorithm to use" values="RSA1024","RSA2048","RSA3072", "RSA4096", "ECCP256","ECCP384", "ED25519", "X25519" enum optional default="RSA2048"
+option "algorithm" A "What algorithm to use" values="RSA1024","RSA2048","RSA3072", "RSA4096", "ECCP256","ECCP384", "ED25519", "X25519", "MLDSA44", "MLDSA65", "MLDSA87", "MLKEM512", "MLKEM768", "MLKEM1024" enum optional default="RSA2048"
 option "hash" H "Hash to use for signatures" values="SHA1","SHA256","SHA384","SHA512" enum optional default="SHA256"
 option "new-key" n "New management key to use for action set-mgm-key, if omitted key will be asked for" string optional
 option "pin-retries" - "Number of retries before the pin code is blocked" int optional dependon="puk-retries"

--- a/tool/yubico-piv-tool.c
+++ b/tool/yubico-piv-tool.c
@@ -57,6 +57,9 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/crypto.h>
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+#include <openssl/provider.h>
+#endif
 #ifdef USE_CERT_COMPRESS
 #include <zlib.h>
 #endif
@@ -328,9 +331,11 @@ static bool generate_key(ykpiv_state *state, enum enum_slot slot,
   uint8_t *mod = NULL;
   uint8_t *exp = NULL;
   uint8_t *point = NULL;
+  uint8_t *pqc_pubkey = NULL;
   size_t mod_len = 0;
   size_t exp_len = 0;
   size_t point_len = 0;
+  size_t pqc_pubkey_len = 0;
 
   key = get_slot_hex(slot);
 
@@ -344,17 +349,19 @@ static bool generate_key(ykpiv_state *state, enum enum_slot slot,
                          "and Technology (NIST). See https://www.yubico.com/blog/comparing-asymmetric-encryption-algorithms\n\n");
   }
 
-  res = ykpiv_util_generate_key(state,
-                                (uint8_t)(key & 0xFF),
-                                get_piv_algorithm(algorithm),
-                                get_pin_policy(pin_policy),
-                                get_touch_policy(touch_policy),
-                                &mod,
-                                &mod_len,
-                                &exp,
-                                &exp_len,
-                                &point,
-                                &point_len);
+  res = ykpiv_util_generate_key_ex(state,
+                                   (uint8_t)(key & 0xFF),
+                                   get_piv_algorithm(algorithm),
+                                   get_pin_policy(pin_policy),
+                                   get_touch_policy(touch_policy),
+                                   &mod,
+                                   &mod_len,
+                                   &exp,
+                                   &exp_len,
+                                   &point,
+                                   &point_len,
+                                   &pqc_pubkey,
+                                   &pqc_pubkey_len);
   if (res != YKPIV_OK) {
     fprintf(stderr, "Key generation failed.\n");
     goto generate_out;
@@ -421,6 +428,36 @@ static bool generate_key(ykpiv_state *state, enum enum_slot slot,
                         "Upgrade OpenSSL to at least 1.1 or use attestation command to get a signed certificate instead.\n");
         return true;
 #endif
+#if (OPENSSL_VERSION_NUMBER >= 0x30500000L)
+      case algorithm_arg_MLDSA44:
+        public_key = EVP_PKEY_new_raw_public_key(NID_ML_DSA_44, NULL, pqc_pubkey, pqc_pubkey_len);
+        break;
+      case algorithm_arg_MLDSA65:
+        public_key = EVP_PKEY_new_raw_public_key(NID_ML_DSA_65, NULL, pqc_pubkey, pqc_pubkey_len);
+        break;
+      case algorithm_arg_MLDSA87:
+        public_key = EVP_PKEY_new_raw_public_key(NID_ML_DSA_87, NULL, pqc_pubkey, pqc_pubkey_len);
+        break;
+      case algorithm_arg_MLKEM512:
+        public_key = EVP_PKEY_new_raw_public_key(NID_ML_KEM_512, NULL, pqc_pubkey, pqc_pubkey_len);
+        break;
+      case algorithm_arg_MLKEM768:
+        public_key = EVP_PKEY_new_raw_public_key(NID_ML_KEM_768, NULL, pqc_pubkey, pqc_pubkey_len);
+        break;
+      case algorithm_arg_MLKEM1024:
+        public_key = EVP_PKEY_new_raw_public_key(NID_ML_KEM_1024, NULL, pqc_pubkey, pqc_pubkey_len);
+        break;
+#else
+      case algorithm_arg_MLDSA44:
+      case algorithm_arg_MLDSA65:
+      case algorithm_arg_MLDSA87:
+      case algorithm_arg_MLKEM512:
+      case algorithm_arg_MLKEM768:
+      case algorithm_arg_MLKEM1024:
+        fprintf(stderr, "Key was generated successfully but a public key cannot be parsed due to too old OpenSSL version. "
+                        "Upgrade OpenSSL to at least 3.5 or use attestation command to get a signed certificate instead.\n");
+        return true;
+#endif
       default:
         fprintf(stderr, "Wrong algorithm.\n");
     }
@@ -459,6 +496,9 @@ generate_out:
   }
   if (point) {
     ykpiv_util_free(state, point);
+  }
+  if (pqc_pubkey) {
+    ykpiv_util_free(state, pqc_pubkey);
   }
   if (mod) {
     ykpiv_util_free(state, mod);
@@ -689,6 +729,47 @@ static bool import_key(ykpiv_state *state, enum enum_key_format key_format,
                                     NULL, 0,
                                     s_ptr, element_len,
                                     pp, tp);
+    }
+#endif
+#if (OPENSSL_VERSION_NUMBER >= 0x30500000L)
+    else if(YKPIV_IS_MLDSA(algorithm) || YKPIV_IS_MLKEM(algorithm)) {
+
+      unsigned char *der_data = NULL;
+      int der_len = i2d_PrivateKey(private_key, &der_data);
+
+      if (der_len <= 0 || !der_data) {
+        fprintf(stderr, "Failed to encode private key to DER.\n");
+        goto import_out;
+      }
+
+      // Search for first OCTET STRING (0x04) with length 32 (0x20) - this is the seed
+      unsigned char *seed_ptr = NULL;
+      for (int i = 0; i < der_len - 33; i++) {
+        if (der_data[i] == 0x04 && der_data[i+1] == 0x20) {
+          seed_ptr = &der_data[i+2];
+          break;
+        }
+      }
+
+      if (!seed_ptr) {
+        fprintf(stderr, "ERROR: Could not find 32-byte seed in DER-encoded private key\n");
+        OPENSSL_free(der_data);
+        goto import_out;
+      }
+
+      unsigned char seed[32];
+      memcpy(seed, seed_ptr, 32);
+      OPENSSL_free(der_data);
+
+      rc = ykpiv_import_private_key_ex(state, key, algorithm,
+                                       NULL, 0,
+                                       NULL, 0,
+                                       NULL, 0,
+                                       NULL, 0,
+                                       NULL, 0,
+                                       NULL, 0,             // ec_data
+                                       seed, 32,            // pqc_privkey (32-byte seed)
+                                       pp, tp);
     }
 #endif
 
@@ -1327,7 +1408,7 @@ static bool selfsign_certificate(ykpiv_state *state, enum enum_key_format key_fo
   size_t oid_len = 0;
   const unsigned char *oid = 0;
   const EVP_MD *md = NULL;
-  if (algorithm != YKPIV_ALGO_ED25519) {
+  if (algorithm != YKPIV_ALGO_ED25519 && !YKPIV_IS_MLDSA(algorithm)) {
     md = get_hash(hash, &oid, &oid_len);
     if (md == NULL) {
       goto selfsign_out;
@@ -1480,7 +1561,7 @@ static bool selfsign_certificate(ykpiv_state *state, enum enum_key_format key_fo
     goto selfsign_out;
   }
   {
-    unsigned char signature[1024] = {0};
+    unsigned char signature[YKPIV_OBJ_MAX_SIZE] = {0};
     size_t sig_len = sizeof(signature);
     if(!sign_data(state, signinput, len, signature, &sig_len, algorithm, key)) {
       fprintf(stderr, "Failed signing certificate.\n");
@@ -1495,30 +1576,49 @@ static bool selfsign_certificate(ykpiv_state *state, enum enum_key_format key_fo
 #else
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
-  if (algorithm == YKPIV_ALGO_ED25519) {
+  if (algorithm == YKPIV_ALGO_ED25519 || YKPIV_IS_MLDSA(algorithm)) {
 
-    // Generate a dummy ED25519 to sign with OpenSSL
-    EVP_PKEY *ed_key = NULL;
-    EVP_PKEY_CTX *ed_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519, NULL);
-    EVP_PKEY_keygen_init(ed_ctx);
-    EVP_PKEY_keygen(ed_ctx, &ed_key);
-    EVP_PKEY_CTX_free(ed_ctx);
+    // Generate a dummy key to sign with OpenSSL (Ed25519 or ML-DSA)
+    EVP_PKEY *sig_key = NULL;
+    EVP_PKEY_CTX *sig_ctx = NULL;
 
-    // Sign the X509 object using the dummy key
-    if (X509_sign(x509, ed_key, md) == 0) {
-      fprintf(stderr, "Failed signing certificate.\n");
-      ERR_print_errors_fp(stderr);
-      EVP_PKEY_free(ed_key);
+    if (algorithm == YKPIV_ALGO_ED25519) {
+      sig_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_ED25519, NULL);
+    }
+#if (OPENSSL_VERSION_NUMBER >= 0x30500000L)
+    else if (algorithm == YKPIV_ALGO_MLDSA44) {
+      sig_ctx = EVP_PKEY_CTX_new_from_name(NULL, "ML-DSA-44", NULL);
+    } else if (algorithm == YKPIV_ALGO_MLDSA65) {
+      sig_ctx = EVP_PKEY_CTX_new_from_name(NULL, "ML-DSA-65", NULL);
+    } else if (algorithm == YKPIV_ALGO_MLDSA87) {
+      sig_ctx = EVP_PKEY_CTX_new_from_name(NULL, "ML-DSA-87", NULL);
+    }
+#endif
+
+    if (!sig_ctx) {
+      fprintf(stderr, "Failed creating context for dummy key.\n");
       goto selfsign_out;
     }
-    EVP_PKEY_free(ed_key);
+
+    EVP_PKEY_keygen_init(sig_ctx);
+    EVP_PKEY_keygen(sig_ctx, &sig_key);
+    EVP_PKEY_CTX_free(sig_ctx);
+
+    // Sign the X509 object using the dummy key
+    if (X509_sign(x509, sig_key, md) == 0) {
+      fprintf(stderr, "Failed signing certificate.\n");
+      ERR_print_errors_fp(stderr);
+      EVP_PKEY_free(sig_key);
+      goto selfsign_out;
+    }
+    EVP_PKEY_free(sig_key);
 
     // Extract the certificate data without the signature
     unsigned char *tbs_data = NULL;
     int tbs_len = i2d_re_X509_tbs(x509, &tbs_data);
 
     // Sign the certificate data using the YubiKey
-    unsigned char yk_sig[512] = {0};
+    unsigned char yk_sig[YKPIV_OBJ_MAX_SIZE] = {0};  // Must fit ML-DSA-87 (4627 bytes)
     size_t yk_siglen = sizeof(yk_sig);
     if (!sign_data(state, tbs_data, tbs_len, yk_sig, &yk_siglen, algorithm, key)) {
       fprintf(stderr, "Failed signing tbs certificate portion.\n");
@@ -1890,6 +1990,24 @@ static void print_algorithm_string(uint8_t algorithm, FILE *output) {
     case YKPIV_ALGO_X25519:
       fprintf(output, "X25519");
       break;
+    case YKPIV_ALGO_MLDSA44:
+      fprintf(output, "ML-DSA-44");
+      break;
+    case YKPIV_ALGO_MLDSA65:
+      fprintf(output, "ML-DSA-65");
+      break;
+    case YKPIV_ALGO_MLDSA87:
+      fprintf(output, "ML-DSA-87");
+      break;
+    case YKPIV_ALGO_MLKEM512:
+      fprintf(output, "ML-KEM-512");
+      break;
+    case YKPIV_ALGO_MLKEM768:
+      fprintf(output, "ML-KEM-768");
+      break;
+    case YKPIV_ALGO_MLKEM1024:
+      fprintf(output, "ML-KEM-1024");
+      break;
     default:
       fprintf(output, "Unknown");
   }
@@ -2168,7 +2286,8 @@ static bool test_signature(ykpiv_state *state, enum enum_slot slot,
   }
 
   {
-    unsigned char signature[1024] = {0};
+    // Buffer sizes: RSA-4096: 512 bytes, ML-DSA-87: 4627 bytes
+    unsigned char signature[5120] = {0};
     unsigned char encoded[1024] = {0};
     unsigned char *ptr = data;
     unsigned int enc_len;
@@ -2253,6 +2372,32 @@ static bool test_signature(ykpiv_state *state, enum enum_slot slot,
             goto test_out;
           } else {
             fprintf(stderr, "Failed EDDSA verification.\n");
+            goto test_out;
+          }
+        }
+        break;
+#endif
+#if (OPENSSL_VERSION_NUMBER >= 0x30500000L)
+      case YKPIV_ALGO_MLDSA44:
+      case YKPIV_ALGO_MLDSA65:
+      case YKPIV_ALGO_MLDSA87:
+        {
+          EVP_MD_CTX *ctx;
+          int rc;
+          ctx = EVP_MD_CTX_new();
+          if (!ctx || EVP_DigestVerifyInit(ctx, NULL, NULL, NULL, pubkey) <= 0) {
+            fprintf(stderr, "Failed routine initialization\n");
+            EVP_MD_CTX_free(ctx);
+            goto test_out;
+          }
+          rc = EVP_DigestVerify(ctx, signature, (int)sig_len, data, (int)data_len);
+          EVP_MD_CTX_free(ctx);
+          if(rc == 1) {
+            fprintf(stderr, "Successful ML-DSA verification.\n");
+            ret = true;
+            goto test_out;
+          } else {
+            fprintf(stderr, "Failed ML-DSA verification.\n");
             goto test_out;
           }
         }
@@ -2445,7 +2590,7 @@ static bool list_readers(ykpiv_state *state) {
 
 static bool attest(ykpiv_state *state, enum enum_slot slot,
     enum enum_key_format key_format, const char *output_file_name) {
-  unsigned char data[2048] = {0};
+  unsigned char data[YKPIV_OBJ_MAX_SIZE] = {0};  // Must fit PQC attestation certs
   size_t len = sizeof(data);
   bool ret = false;
   X509 *x509 = NULL;
@@ -2665,6 +2810,17 @@ int main(int argc, char *argv[]) {
   OpenSSL_add_all_algorithms();
 #else
   OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, 0);
+#endif
+
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+  // TODO: shouldn't this be loaded by default?
+  // Load OpenSSL default provider for PQC algorithm support
+  OSSL_PROVIDER *default_provider = OSSL_PROVIDER_load(NULL, "default");
+  if (default_provider == NULL) {
+    fprintf(stderr, "Warning: Failed to load OpenSSL default provider\n");
+    // TODO: exit error or continue without PQC support?
+  }
+  // TODO: probably need to OSSL_PROVIDER_unload(default_provider);
 #endif
 
   if((rc = ykpiv_init(&state, verbosity)) != YKPIV_OK) {


### PR DESCRIPTION
Bump version to 2.8.0 and add support for NIST-standardized PQC algorithms: ML-DSA-44/65/87 (signature) and ML-KEM-512/768/1024 (key encapsulation).

- Add ykpiv_util_generate_key_ex() and ykpiv_import_private_key_ex() APIs to support PQC public key and private key parameters
- Increase buffer sizes to CB_BUF_MAX_YK6 (4928 bytes) for PQC operations
- Add OpenSSL 3.5+ support for PQC algorithm NIDs and raw key operations
- Add command line algorithm options and PQC provider initialization
- Support YubiKey 6.0+ device-specific buffer sizes