### PR TITLE
Test oversized key components without hardware

### DIFF
--- a/lib/tests/api.c
+++ b/lib/tests/api.c
@@ -357,19 +357,6 @@ static void import_key(unsigned char slot, unsigned char pin_policy) {
     iqmp_len = element_len;
     ck_assert(set_component(iqmp, bn_iqmp, &iqmp_len));
 
-    // Try wrong algorithm, fail.
-    res = ykpiv_import_private_key(g_state,
-                                   slot,
-                                   YKPIV_ALGO_RSA1024,
-                                   p, p_len,
-                                   q, q_len,
-                                   dmp1, dmp1_len,
-                                   dmq1, dmq1_len,
-                                   iqmp, iqmp_len,
-                                   NULL, 0,
-                                   pp, tp);
-    ck_assert_int_eq(res, YKPIV_ALGORITHM_ERROR);
-
     // Try right algorithm
     res = ykpiv_import_private_key(g_state,
                                    slot,

--- a/lib/tests/basic.c
+++ b/lib/tests/basic.c
@@ -70,6 +70,27 @@ START_TEST(test_strerror) {
 }
 END_TEST
 
+START_TEST(test_import_key_rejects_oversized_components) {
+  ykpiv_state *state = NULL;
+  unsigned char component[256] = {0};
+
+  ck_assert_int_eq(ykpiv_init(&state, false), YKPIV_OK);
+  ck_assert_int_eq(
+    ykpiv_import_private_key(state, YKPIV_KEY_AUTHENTICATION,
+                             YKPIV_ALGO_RSA1024,
+                             component, sizeof(component),
+                             component, sizeof(component),
+                             component, sizeof(component),
+                             component, sizeof(component),
+                             component, sizeof(component),
+                             NULL, 0,
+                             YKPIV_PINPOLICY_DEFAULT,
+                             YKPIV_TOUCHPOLICY_DEFAULT),
+    YKPIV_ARGUMENT_ERROR);
+  ck_assert_int_eq(ykpiv_done(state), YKPIV_OK);
+}
+END_TEST
+
 static Suite *basic_suite(void) {
   Suite *s;
   TCase *tc;
@@ -78,6 +99,7 @@ static Suite *basic_suite(void) {
   tc = tcase_create("basic");
   tcase_add_test(tc, test_version_string);
   tcase_add_test(tc, test_strerror);
+  tcase_add_test(tc, test_import_key_rejects_oversized_components);
   suite_add_tcase(s, tc);
 
   return s;


### PR DESCRIPTION
## Summary

- move oversized RSA-component validation out of the hardware import helper
- cover the validation once in the non-hardware basic test suite
- expect `YKPIV_ARGUMENT_ERROR`, matching the current public behavior

## Rationale

`ykpiv_import_private_key()` rejects components larger than the selected algorithm's `elem_len` before beginning a transaction. The existing check inside the shared hardware helper expected `YKPIV_ALGORITHM_ERROR`, even though the production validation returns `YKPIV_ARGUMENT_ERROR`.

Because `test_import_key`, `test_pin_policy_always`, and `test_pin_cache` all used that helper, the same host-side assertion ran three times and could prevent the device-specific parts of those tests from running.

The production code is unchanged. Valid hardware imports remain in the hardware suite, while oversized input validation now has a standalone test that requires no connected YubiKey.

## Follow-up suggestion

A separate hardware conformance test could bypass the public validation with `ykpiv_transfer_data()`, send an oversized raw Import Key APDU, and assert the YubiKey's response and that the target slot remains unchanged. Keeping that separate would distinguish device behavior from this API input-validation test.

## Testing

- `cmake --build build-hardware --parallel`
- `ctest --test-dir build-hardware -R '^basic$' --output-on-failure -V`
